### PR TITLE
FEAT-CORE-003: initialize Neo4j embedded DB

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,5 +4,7 @@ plugins {
 
 dependencies {
     implementation("io.github.classgraph:classgraph:4.8.180")
+    implementation("org.neo4j.test:neo4j-harness:5.19.0")
+    implementation("org.neo4j.driver:neo4j-java-driver:5.19.0")
 }
 

--- a/core/src/main/java/com/example/core/db/EmbeddedNeo4j.java
+++ b/core/src/main/java/com/example/core/db/EmbeddedNeo4j.java
@@ -1,0 +1,36 @@
+package com.example.core.db;
+
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.harness.Neo4j;
+import org.neo4j.harness.Neo4jBuilders;
+import com.example.core.db.NodeLabel;
+
+/**
+ * Helper class to manage an embedded Neo4j instance.
+ */
+public class EmbeddedNeo4j implements AutoCloseable {
+    private final Neo4j neo4j;
+    private final Driver driver;
+
+    public EmbeddedNeo4j() {
+        this.neo4j = Neo4jBuilders.newInProcessBuilder().build();
+        this.driver = GraphDatabase.driver(neo4j.boltURI(), AuthTokens.none());
+        // ensure index on Class name
+        try (Session session = driver.session()) {
+            session.run("CREATE INDEX class_name IF NOT EXISTS FOR (c:" + NodeLabel.CLASS + ") ON (c.name)");
+        }
+    }
+
+    public Driver getDriver() {
+        return driver;
+    }
+
+    @Override
+    public void close() {
+        driver.close();
+        neo4j.close();
+    }
+}

--- a/core/src/main/java/com/example/core/db/NodeLabel.java
+++ b/core/src/main/java/com/example/core/db/NodeLabel.java
@@ -1,0 +1,14 @@
+package com.example.core.db;
+
+/**
+ * Enumerates the labels used in the Neo4j graph schema.
+ */
+public enum NodeLabel {
+    CLASS,
+    METHOD;
+
+    @Override
+    public String toString() {
+        return name();
+    }
+}

--- a/core/src/test/java/com/example/core/EmbeddedNeo4jTest.java
+++ b/core/src/test/java/com/example/core/EmbeddedNeo4jTest.java
@@ -1,0 +1,26 @@
+package com.example.core;
+
+import com.example.core.db.EmbeddedNeo4j;
+import com.example.core.db.NodeLabel;
+import org.junit.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Record;
+
+import java.util.List;
+
+public class EmbeddedNeo4jTest {
+    @Test
+    public void createNode_queryByLabel_returnsNode() {
+        try (EmbeddedNeo4j db = new EmbeddedNeo4j()) {
+            Driver driver = db.getDriver();
+            try (Session session = driver.session()) {
+                session.run("CREATE (c:" + NodeLabel.CLASS + " {name:'Foo'})");
+                List<Record> result = session.run("MATCH (c:" + NodeLabel.CLASS + ") RETURN c").list();
+                if (result.isEmpty()) {
+                    throw new AssertionError("Node not found");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add NodeLabel enum with CLASS and METHOD labels
- embed NodeLabel usage in EmbeddedNeo4j index creation
- update unit test to use NodeLabel constants

## Testing
- `gradle :core:test --no-daemon --console=plain`
- `gradle build --no-daemon --console=plain`
- `gradle spotlessApply --no-daemon --console=plain` *(fails: Task not found)*

------
https://chatgpt.com/codex/tasks/task_b_686daa1707b0832abfa27c31fed4c4a3