### PR TITLE
FEAT-CORE-004: Graph persistence

### DIFF
--- a/core/src/main/java/com/example/core/GraphImporter.java
+++ b/core/src/main/java/com/example/core/GraphImporter.java
@@ -1,5 +1,7 @@
 package com.example.core;
 
+import org.neo4j.driver.Driver;
+
 public interface GraphImporter {
-    void importJar(java.io.File jar);
+    void importJar(java.io.File jar, Driver driver);
 }

--- a/core/src/main/java/com/example/core/JarImporter.java
+++ b/core/src/main/java/com/example/core/JarImporter.java
@@ -2,6 +2,10 @@ package com.example.core;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Values;
+import com.example.core.db.NodeLabel;
 import java.io.File;
 import java.util.List;
 import java.util.logging.Level;
@@ -18,11 +22,12 @@ public class JarImporter {
     }
 
     /**
-     * Import the given JAR file into the graph. Implementation to follow.
+     * Import the given JAR file into the graph.
      *
      * @param jar the JAR file to import
+     * @param driver the Neo4j driver to use for persistence
      */
-    public static void importJar(File jar) {
+    public static void importJar(File jar, Driver driver) {
         try {
             LOGGER.info("Importing JAR: " + jar.getAbsolutePath());
 
@@ -32,6 +37,13 @@ public class JarImporter {
                     .scan()) {
                 List<String> classes = scan.getAllClasses().getNames();
                 LOGGER.info("Classes: " + classes);
+                try (Session session = driver.session()) {
+                    for (String cls : classes) {
+                        session.run(
+                                "MERGE (c:" + NodeLabel.CLASS + " {name:$name})",
+                                Values.parameters("name", cls));
+                    }
+                }
             }
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to import JAR", e);


### PR DESCRIPTION
## Summary
- extend `JarImporter` to persist class nodes
- update `GraphImporter` interface
- test Neo4j persistence when importing a JAR

## Testing
- `gradle :core:test`
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_b_686db291a490832a88dcf5ac20144c71