### PR TITLE
FEAT-CORE-005: persist class dependencies

### DIFF
--- a/core/src/main/java/tech/softwareologists/core/JarImporter.java
+++ b/core/src/main/java/tech/softwareologists/core/JarImporter.java
@@ -1,6 +1,7 @@
 package tech.softwareologists.core;
 
 import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ScanResult;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
@@ -34,14 +35,30 @@ public class JarImporter {
             try (ScanResult scan = new ClassGraph()
                     .overrideClasspath(jar)
                     .enableClassInfo()
+                    .enableInterClassDependencies()
                     .scan()) {
                 List<String> classes = scan.getAllClasses().getNames();
                 LOGGER.info("Classes: " + classes);
                 try (Session session = driver.session()) {
-                    for (String cls : classes) {
+                    for (ClassInfo classInfo : scan.getAllClasses()) {
+                        String cls = classInfo.getName();
                         session.run(
                                 "MERGE (c:" + NodeLabel.CLASS + " {name:$name})",
                                 Values.parameters("name", cls));
+
+                        java.util.Set<String> seenDeps = new java.util.HashSet<>();
+                        for (ClassInfo dep : classInfo.getClassDependencies()) {
+                            String depName = dep.getName();
+                            if (cls.equals(depName) || !seenDeps.add(depName)) {
+                                continue;
+                            }
+                            session.run(
+                                    "MERGE (d:" + NodeLabel.CLASS + " {name:$dep})",
+                                    Values.parameters("dep", depName));
+                            session.run(
+                                    "MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS + " {name:$tgt}) MERGE (s)-[:DEPENDS_ON]->(t)",
+                                    Values.parameters("src", cls, "tgt", depName));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- capture dependencies with `ClassInfo#getClassDependencies`
- persist `DEPENDS_ON` edges between class nodes
- deduplicate dependency edges
- test class dependencies using EmbeddedNeo4j

## Testing
- `gradle :core:test`
- `gradle spotlessApply` *(fails: Task 'spotlessApply' not found)*
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_b_686dc08d10a0832aa657f0b345dec0ab