### PR TITLE
FEAT-CORE-006: implement query service

### DIFF
--- a/core/src/main/java/tech/softwareologists/core/QueryServiceImpl.java
+++ b/core/src/main/java/tech/softwareologists/core/QueryServiceImpl.java
@@ -1,0 +1,29 @@
+package tech.softwareologists.core;
+
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Values;
+import tech.softwareologists.core.db.NodeLabel;
+
+import java.util.List;
+
+/**
+ * Default implementation of {@link QueryService} backed by a Neo4j driver.
+ */
+public class QueryServiceImpl implements QueryService {
+    private final Driver driver;
+
+    public QueryServiceImpl(Driver driver) {
+        this.driver = driver;
+    }
+
+    @Override
+    public List<String> findCallers(String className) {
+        try (Session session = driver.session()) {
+            return session.run(
+                    "MATCH (c:" + NodeLabel.CLASS + ")-[:DEPENDS_ON]->(t:" + NodeLabel.CLASS + " {name:$name}) RETURN c.name AS name",
+                    Values.parameters("name", className))
+                    .list(r -> r.get("name").asString());
+        }
+    }
+}

--- a/core/src/test/java/tech/softwareologists/core/QueryServiceImplTest.java
+++ b/core/src/test/java/tech/softwareologists/core/QueryServiceImplTest.java
@@ -1,0 +1,29 @@
+package tech.softwareologists.core;
+
+import org.junit.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import tech.softwareologists.core.db.EmbeddedNeo4j;
+import tech.softwareologists.core.db.NodeLabel;
+
+import java.util.List;
+
+public class QueryServiceImplTest {
+    @Test
+    public void findCallers_singleDependency_returnsCaller() {
+        try (EmbeddedNeo4j db = new EmbeddedNeo4j()) {
+            Driver driver = db.getDriver();
+            try (Session session = driver.session()) {
+                session.run("CREATE (:" + NodeLabel.CLASS + " {name:'dep.A'})");
+                session.run("CREATE (:" + NodeLabel.CLASS + " {name:'dep.B'})");
+                session.run("MATCH (b:" + NodeLabel.CLASS + " {name:'dep.B'}), (a:" + NodeLabel.CLASS + " {name:'dep.A'}) CREATE (b)-[:DEPENDS_ON]->(a)");
+            }
+
+            QueryService service = new QueryServiceImpl(driver);
+            List<String> callers = service.findCallers("dep.A");
+            if (callers.size() != 1 || !callers.get(0).equals("dep.B")) {
+                throw new AssertionError("Unexpected callers: " + callers);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement QueryServiceImpl for Neo4j backed lookups
- add unit test for QueryServiceImpl

## Testing
- `gradle :core:test`


------
https://chatgpt.com/codex/tasks/task_b_686dc6ae82c4832a8b8667898a63075a