### PR TITLE
FEAT-DOC-003: Add module-aware CI pipeline

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  modules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            core:
+              - 'core/**'
+            cli:
+              - 'cli/**'
+            intellij:
+              - 'intellij/**'
+      - name: Spotless Check
+        run: gradle spotlessCheck
+      - name: Core Tests
+        if: steps.changes.outputs.core == 'true'
+        run: gradle :core:test
+      - name: CLI Tests
+        if: steps.changes.outputs.cli == 'true'
+        run: gradle :cli:test
+      - name: IntelliJ Plugin Build
+        if: steps.changes.outputs.intellij == 'true'
+        run: gradle :intellij:buildPlugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,11 @@
 plugins {
     `java-library`
+    id("com.diffplug.spotless") version "6.25.0"
 }
 
 subprojects {
     apply(plugin = "java")
+    apply(plugin = "com.diffplug.spotless")
 
     repositories {
         mavenCentral()
@@ -16,5 +18,13 @@ subprojects {
     tasks.withType<JavaCompile> {
         sourceCompatibility = "11"
         targetCompatibility = "11"
+    }
+
+    spotless {
+        java {
+            target("src/**/*.java")
+            trimTrailingWhitespace()
+            endWithNewline()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Gradle tasks
- detect changed modules and run only relevant tests

## Testing
- `gradle :core:test`
- `gradle :cli:test`
- `gradle :intellij:buildPlugin` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_686dd18990a0832ab4a947aba8bb39a0