### PR TITLE
FEAT-CORE-007: implement manifest generator

### DIFF
--- a/core/manifest.json.tpl
+++ b/core/manifest.json.tpl
@@ -1,5 +1,7 @@
 {
   "name": "CodeGraph MCP",
   "version": "0.1.0",
-  "capabilities": []
+  "capabilities": [
+    { "name": "findCallers", "params": ["className"] }
+  ]
 }

--- a/core/src/main/java/tech/softwareologists/core/ManifestGenerator.java
+++ b/core/src/main/java/tech/softwareologists/core/ManifestGenerator.java
@@ -1,0 +1,46 @@
+package tech.softwareologists.core;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+/**
+ * Utility to generate the MCP manifest by reflecting on {@link QueryService}.
+ */
+public class ManifestGenerator {
+    private ManifestGenerator() {
+        // utility class
+    }
+
+    /**
+     * Generate the manifest JSON string listing available query capabilities.
+     *
+     * @return JSON manifest
+     */
+    public static String generate() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append("  \"name\": \"CodeGraph MCP\",\n");
+        sb.append("  \"version\": \"0.1.0\",\n");
+        sb.append("  \"capabilities\": [");
+
+        Method[] methods = QueryService.class.getDeclaredMethods();
+        for (int i = 0; i < methods.length; i++) {
+            Method m = methods[i];
+            sb.append("{\"name\":\"").append(m.getName()).append("\",\"params\":[");
+            Parameter[] params = m.getParameters();
+            for (int j = 0; j < params.length; j++) {
+                if (j > 0) {
+                    sb.append(',');
+                }
+                sb.append('"').append(params[j].getName()).append('"');
+            }
+            sb.append("]}");
+            if (i < methods.length - 1) {
+                sb.append(',');
+            }
+        }
+        sb.append("]\n");
+        sb.append("}\n");
+        return sb.toString();
+    }
+}

--- a/core/src/test/java/tech/softwareologists/core/ManifestGeneratorTest.java
+++ b/core/src/test/java/tech/softwareologists/core/ManifestGeneratorTest.java
@@ -1,0 +1,13 @@
+package tech.softwareologists.core;
+
+import org.junit.Test;
+
+public class ManifestGeneratorTest {
+    @Test
+    public void generate_containsFindCallersCapability() {
+        String manifest = ManifestGenerator.generate();
+        if (!manifest.contains("findCallers")) {
+            throw new AssertionError("Manifest missing findCallers capability: " + manifest);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement ManifestGenerator to build JSON manifest by reflecting on QueryService
- update manifest.json.tpl with example capability output
- test ManifestGenerator for basic capability contents

## Testing
- `gradle :core:test --no-daemon`
- `gradle spotlessApply --no-daemon`


------
https://chatgpt.com/codex/tasks/task_b_686ddbd534bc832aaba9773e0906ab0b