### PR TITLE
FEAT-CLI-001: add CliMain usage helper

### DIFF
--- a/cli/src/main/java/tech/softwareologists/cli/CliMain.java
+++ b/cli/src/main/java/tech/softwareologists/cli/CliMain.java
@@ -1,0 +1,64 @@
+package tech.softwareologists.cli;
+
+import java.io.PrintStream;
+
+/**
+ * Simple command line entry point for the MCP CLI.
+ */
+public class CliMain {
+    /** Usage string shown when arguments are missing or --help is supplied. */
+    public static final String USAGE = "Usage: cli --watch-dir <dir> [--stdio]";
+
+    public static void main(String[] args) {
+        int code = run(args, System.out);
+        if (code != 0) {
+            System.exit(code);
+        }
+    }
+
+    /**
+     * Runs the CLI with the given arguments and output stream.
+     *
+     * @param args command line arguments
+     * @param out where to print output
+     * @return exit code
+     */
+    static int run(String[] args, PrintStream out) {
+        String watchDir = null;
+        boolean stdio = false;
+        boolean help = false;
+
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            switch (arg) {
+                case "--help":
+                case "-h":
+                    help = true;
+                    break;
+                case "--watch-dir":
+                    if (i + 1 >= args.length) {
+                        out.println(USAGE);
+                        return 1;
+                    }
+                    watchDir = args[++i];
+                    break;
+                case "--stdio":
+                    stdio = true;
+                    break;
+                default:
+                    out.println("Unknown option: " + arg);
+                    out.println(USAGE);
+                    return 1;
+            }
+        }
+
+        if (help || watchDir == null) {
+            out.println(USAGE);
+            return help ? 0 : 1;
+        }
+
+        // Placeholder for actual functionality
+        out.println("Starting with watchDir=" + watchDir + " stdio=" + stdio);
+        return 0;
+    }
+}

--- a/cli/src/test/java/tech/softwareologists/cli/CliMainTest.java
+++ b/cli/src/test/java/tech/softwareologists/cli/CliMainTest.java
@@ -1,0 +1,21 @@
+package tech.softwareologists.cli;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class CliMainTest {
+    @Test
+    public void help_printsUsage() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int code = CliMain.run(new String[] {"--help"}, new PrintStream(baos));
+        String output = baos.toString().trim();
+        if (!CliMain.USAGE.equals(output)) {
+            throw new AssertionError("Expected usage but was: " + output);
+        }
+        if (code != 0) {
+            throw new AssertionError("Expected exit code 0 but was: " + code);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CliMain` with simple argument parsing
- show usage when run with `--help`
- test the help output

## Testing
- `gradle build` *(fails: PluginTest > initializationError)*
- `gradle :cli:test`


------
https://chatgpt.com/codex/tasks/task_b_686de9fb8984832abf1900dd68bd13de