### PR TITLE
FEAT-CLI-002: Implement JarWatcher

### DIFF
--- a/cli/src/main/java/tech/softwareologists/cli/JarWatcher.java
+++ b/cli/src/main/java/tech/softwareologists/cli/JarWatcher.java
@@ -1,0 +1,66 @@
+package tech.softwareologists.cli;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Watches a directory for newly created JAR files and logs their paths.
+ */
+public class JarWatcher implements AutoCloseable {
+    private static final Logger LOGGER = Logger.getLogger(JarWatcher.class.getName());
+
+    private final Path directory;
+    private final WatchService watchService;
+    private Thread thread;
+
+    /**
+     * Creates a watcher for the given directory. The watcher is not started
+     * until {@link #start()} is called.
+     */
+    public JarWatcher(Path directory) throws IOException {
+        this.directory = directory;
+        this.watchService = directory.getFileSystem().newWatchService();
+        directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+    }
+
+    /** Starts watching in a background thread. */
+    public void start() {
+        if (thread != null) {
+            return;
+        }
+        thread = new Thread(this::process);
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private void process() {
+        try {
+            while (!Thread.currentThread().isInterrupted()) {
+                WatchKey key = watchService.take();
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                        Path created = directory.resolve((Path) event.context());
+                        if (created.toString().endsWith(".jar")) {
+                            LOGGER.info("Detected JAR: " + created.toAbsolutePath());
+                        }
+                    }
+                }
+                if (!key.reset()) {
+                    break;
+                }
+            }
+        } catch (InterruptedException ignored) {
+            // exit
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (thread != null) {
+            thread.interrupt();
+        }
+        watchService.close();
+    }
+}

--- a/cli/src/test/java/tech/softwareologists/cli/JarWatcherTest.java
+++ b/cli/src/test/java/tech/softwareologists/cli/JarWatcherTest.java
@@ -1,0 +1,61 @@
+package tech.softwareologists.cli;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+public class JarWatcherTest {
+    @Test
+    public void jarCreation_logged() throws Exception {
+        Path dir = Files.createTempDirectory("watch-test");
+
+        Logger logger = Logger.getLogger(JarWatcher.class.getName());
+        logger.setUseParentHandlers(false);
+        RecordingHandler handler = new RecordingHandler();
+        logger.addHandler(handler);
+
+        JarWatcher watcher = new JarWatcher(dir);
+        watcher.start();
+
+        Files.createFile(dir.resolve("sample.jar"));
+
+        for (int i = 0; i < 10 && handler.records.isEmpty(); i++) {
+            Thread.sleep(100);
+        }
+
+        watcher.close();
+        logger.removeHandler(handler);
+
+        if (handler.records.isEmpty()) {
+            throw new AssertionError("No log records emitted");
+        }
+        String msg = handler.records.get(0).getMessage();
+        if (!msg.contains("sample.jar")) {
+            throw new AssertionError("Log did not contain jar name: " + msg);
+        }
+    }
+
+    private static class RecordingHandler extends Handler {
+        final List<LogRecord> records = new ArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getLevel().intValue() >= Level.INFO.intValue()) {
+                records.add(record);
+            }
+        }
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void close() throws SecurityException {}
+    }
+}


### PR DESCRIPTION
## Summary
- add `JarWatcher` using `WatchService`
- log jar creation events at INFO level
- add unit test verifying log output when a JAR is created

## Testing
- `gradle spotlessApply`
- `gradle :cli:test`


------
https://chatgpt.com/codex/tasks/task_b_686decf8dea8832abe4a327401d74cb4