### PR TITLE
FEAT-CLI-005: Create runnable CLI fat jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,23 @@ java-codegraph-mcp-server/
    ```bash
    ./gradlew :cli:shadowJar
    ```
-2. **Run the watcher**
+2. **Check the built jar**
+
+   ```bash
+   java -jar cli/build/libs/cli-all.jar --help
+   ```
+3. **Run the watcher**
 
    ```bash
    java -jar cli/build/libs/cli-all.jar --watch-dir /path/to/jars --stdio
    ```
-3. **Send MCP Requests**
+4. **Send MCP Requests**
 
    * At startup, the manifest JSON is printed.
    * Send JSON queries on stdin; responses appear on stdout.
+
+For a full demonstration, run `examples/sample-cli.sh` which assembles the jar,
+imports a sample JAR, and executes a query.
 
 ## IntelliJ Plugin
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,9 +1,16 @@
 plugins {
     application
+    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 application {
-    mainClass.set("tech.softwareologists.cli.Main")
+    mainClass.set("tech.softwareologists.cli.CliMain")
+}
+
+tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
+    archiveFileName.set("cli-all.jar")
+    manifest.attributes(mapOf("Main-Class" to "tech.softwareologists.cli.CliMain"))
+    isZip64 = true
 }
 
 dependencies {

--- a/core/src/main/java/tech/softwareologists/core/db/EmbeddedNeo4j.java
+++ b/core/src/main/java/tech/softwareologists/core/db/EmbeddedNeo4j.java
@@ -16,7 +16,9 @@ public class EmbeddedNeo4j implements AutoCloseable {
     private final Driver driver;
 
     public EmbeddedNeo4j() {
-        this.neo4j = Neo4jBuilders.newInProcessBuilder().build();
+        this.neo4j = Neo4jBuilders.newInProcessBuilder()
+                .withDisabledServer()
+                .build();
         this.driver = GraphDatabase.driver(neo4j.boltURI(), AuthTokens.none());
         // ensure index on Class name
         try (Session session = driver.session()) {

--- a/examples/sample-cli.sh
+++ b/examples/sample-cli.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Build CLI distribution to get runnable script
+# Build CLI fat JAR
 cd "$ROOT_DIR"
-gradle -q :cli:installDist
-CLI_BIN="$ROOT_DIR/cli/build/install/cli/bin/cli"
+gradle -q :cli:shadowJar
+CLI_JAR="$ROOT_DIR/cli/build/libs/cli-all.jar"
 
 # Prepare watch directory with sample jar
 WATCH_DIR="$(mktemp -d)"
@@ -26,7 +26,8 @@ javac -d "$SRC_DIR" "$SRC_DIR/dep/A.java" "$SRC_DIR/dep/B.java"
 jar cf "$WATCH_DIR/callers.jar" -C "$SRC_DIR" dep/A.class -C "$SRC_DIR" dep/B.class
 
 # Run CLI with the generated jar and send a sample query
-"$CLI_BIN" --watch-dir "$WATCH_DIR" --stdio <<EOF_QUERY
+JAVA_OPTS="-Dserver.config.strict_validation.enabled=false"
+java $JAVA_OPTS -jar "$CLI_JAR" --watch-dir "$WATCH_DIR" --stdio <<EOF_QUERY
 {"findCallers":"dep.A"}
 EOF_QUERY
 


### PR DESCRIPTION
## Summary
- build cli-all.jar with the Shadow plugin
- disable the embedded Neo4j server for examples
- update sample script to build the jar and run a demo query
- document jar usage and verification in README

## Testing
- `gradle spotlessApply`
- `gradle :cli:test`
- `gradle :cli:shadowJar`
- `java -jar cli/build/libs/cli-all.jar --help`
- `bash examples/sample-cli.sh` *(fails: Unrecognized setting server.memory.pagecache.size)*

------
https://chatgpt.com/codex/tasks/task_b_686e1dab1c10832aa1788b66afc80a56