### PR TITLE
FEAT-CLI-006: project directory importer

### DIFF
--- a/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
+++ b/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
@@ -1,0 +1,71 @@
+package tech.softwareologists.cli;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Values;
+import tech.softwareologists.core.db.NodeLabel;
+
+import java.io.File;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Utility class to import compiled class files from a directory.
+ */
+public class ProjectDirImporter {
+    private static final Logger LOGGER = Logger.getLogger(ProjectDirImporter.class.getName());
+
+    private ProjectDirImporter() {
+        // utility class
+    }
+
+    /**
+     * Import the compiled classes in the given directory into the graph.
+     *
+     * @param dir    directory containing compiled .class files
+     * @param driver Neo4j driver used for persistence
+     */
+    public static void importDir(File dir, Driver driver) {
+        try {
+            LOGGER.info("Importing directory: " + dir.getAbsolutePath());
+
+            try (ScanResult scan = new ClassGraph()
+                    .overrideClasspath(dir)
+                    .enableClassInfo()
+                    .enableInterClassDependencies()
+                    .scan()) {
+                List<String> classes = scan.getAllClasses().getNames();
+                LOGGER.info("Classes: " + classes);
+                try (Session session = driver.session()) {
+                    for (ClassInfo classInfo : scan.getAllClasses()) {
+                        String cls = classInfo.getName();
+                        session.run(
+                                "MERGE (c:" + NodeLabel.CLASS + " {name:$name})",
+                                Values.parameters("name", cls));
+
+                        java.util.Set<String> seenDeps = new java.util.HashSet<>();
+                        for (ClassInfo dep : classInfo.getClassDependencies()) {
+                            String depName = dep.getName();
+                            if (cls.equals(depName) || !seenDeps.add(depName)) {
+                                continue;
+                            }
+                            session.run(
+                                    "MERGE (d:" + NodeLabel.CLASS + " {name:$dep})",
+                                    Values.parameters("dep", depName));
+                            session.run(
+                                    "MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS + " {name:$tgt}) MERGE (s)-[:DEPENDS_ON]->(t)",
+                                    Values.parameters("src", cls, "tgt", depName));
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to import directory", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/cli/src/test/java/tech/softwareologists/cli/ProjectDirImporterTest.java
+++ b/cli/src/test/java/tech/softwareologists/cli/ProjectDirImporterTest.java
@@ -1,0 +1,50 @@
+package tech.softwareologists.cli;
+
+import org.junit.Test;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Record;
+import tech.softwareologists.core.db.EmbeddedNeo4j;
+import tech.softwareologists.core.db.NodeLabel;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class ProjectDirImporterTest {
+    @Test
+    public void importDir_compiledProject_persistsNodes() throws Exception {
+        Path srcDir = Files.createTempDirectory("projsrc");
+        Path pkgDir = srcDir.resolve("foo");
+        Files.createDirectories(pkgDir);
+        Path srcFile = pkgDir.resolve("Bar.java");
+        Files.write(srcFile, "package foo; public class Bar {}".getBytes(StandardCharsets.UTF_8));
+
+        Path outDir = Files.createTempDirectory("projclasses");
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new IllegalStateException("Java compiler not available");
+        }
+        int res = compiler.run(null, null, null, "-d", outDir.toString(), srcFile.toString());
+        if (res != 0) {
+            throw new IllegalStateException("Compilation failed");
+        }
+
+        try (EmbeddedNeo4j db = new EmbeddedNeo4j()) {
+            Driver driver = db.getDriver();
+            ProjectDirImporter.importDir(outDir.toFile(), driver);
+
+            try (Session session = driver.session()) {
+                List<Record> result = session.run("MATCH (c:" + NodeLabel.CLASS + " {name:'foo.Bar'}) RETURN c").list();
+                if (result.isEmpty()) {
+                    throw new AssertionError("Node foo.Bar not persisted");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ProjectDirImporter` for scanning compiled classes
- persist classes and dependencies in Neo4j
- test compilation of a small project and graph persistence

## Testing
- `gradle :cli:test`
- `gradle spotlessApply`

------
https://chatgpt.com/codex/tasks/task_b_686e24270930832abee8d3225e28a068