### PR TITLE
FEAT-CLI-007: import project directory via flag

### DIFF
--- a/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
+++ b/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
@@ -24,12 +24,14 @@ public class ProjectDirImporter {
     }
 
     /**
-     * Import the compiled classes in the given directory into the graph.
+     * Import the compiled classes in the given directory into the graph and
+     * return the number of classes discovered.
      *
      * @param dir    directory containing compiled .class files
      * @param driver Neo4j driver used for persistence
+     * @return number of classes imported
      */
-    public static void importDir(File dir, Driver driver) {
+    public static int importDirectory(File dir, Driver driver) {
         try {
             LOGGER.info("Importing directory: " + dir.getAbsolutePath());
 
@@ -62,10 +64,19 @@ public class ProjectDirImporter {
                         }
                     }
                 }
+                LOGGER.info("Imported " + classes.size() + " classes");
+                return classes.size();
             }
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to import directory", e);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Backwards compatible wrapper for {@link #importDirectory(File, Driver)}.
+     */
+    public static void importDir(File dir, Driver driver) {
+        importDirectory(dir, driver);
     }
 }

--- a/cli/src/test/java/tech/softwareologists/cli/CliMainProjectDirTest.java
+++ b/cli/src/test/java/tech/softwareologists/cli/CliMainProjectDirTest.java
@@ -1,0 +1,59 @@
+package tech.softwareologists.cli;
+
+import org.junit.Test;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+public class CliMainProjectDirTest {
+    @Test
+    public void projectDirFlag_importsClasses() throws Exception {
+        Path srcDir = Files.createTempDirectory("cliProjSrc");
+        Path pkgDir = srcDir.resolve("pd");
+        Files.createDirectories(pkgDir);
+        Path srcFile = pkgDir.resolve("Foo.java");
+        Files.writeString(srcFile, "package pd; public class Foo {}", StandardCharsets.UTF_8);
+
+        Path outDir = Files.createTempDirectory("cliProjClasses");
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new IllegalStateException("Java compiler not available");
+        }
+        int res = compiler.run(null, null, null, "-d", outDir.toString(), srcFile.toString());
+        if (res != 0) {
+            throw new IllegalStateException("Compilation failed");
+        }
+
+        Path watch = Files.createTempDirectory("watch");
+
+        Logger logger = Logger.getLogger(CliMain.class.getName());
+        logger.setUseParentHandlers(false);
+        logger.setLevel(Level.INFO);
+        ByteArrayOutputStream logOut = new ByteArrayOutputStream();
+        Handler handler = new StreamHandler(logOut, new SimpleFormatter());
+        logger.addHandler(handler);
+
+        int code = CliMain.run(new String[]{"--watch-dir", watch.toString(), "--project-dir", outDir.toString()}, new PrintStream(new ByteArrayOutputStream()));
+
+        handler.flush();
+        logger.removeHandler(handler);
+        String logs = logOut.toString(StandardCharsets.UTF_8.name());
+        if (code != 0) {
+            throw new AssertionError("CLI exited with code " + code);
+        }
+        if (!logs.contains("Imported 1")) {
+            throw new AssertionError("Import log not found: " + logs);
+        }
+    }
+}

--- a/cli/src/test/java/tech/softwareologists/cli/ProjectDirImporterTest.java
+++ b/cli/src/test/java/tech/softwareologists/cli/ProjectDirImporterTest.java
@@ -37,7 +37,10 @@ public class ProjectDirImporterTest {
 
         try (EmbeddedNeo4j db = new EmbeddedNeo4j()) {
             Driver driver = db.getDriver();
-            ProjectDirImporter.importDir(outDir.toFile(), driver);
+            int count = ProjectDirImporter.importDirectory(outDir.toFile(), driver);
+            if (count != 1) {
+                throw new AssertionError("Expected 1 class but was: " + count);
+            }
 
             try (Session session = driver.session()) {
                 List<Record> result = session.run("MATCH (c:" + NodeLabel.CLASS + " {name:'foo.Bar'}) RETURN c").list();


### PR DESCRIPTION
## Summary
- extend `CliMain` to accept `--project-dir`
- import compiled classes before starting watchers
- log how many classes were imported
- expose new `ProjectDirImporter.importDirectory` API
- test project directory import and CLI flag

## Testing
- `gradle :cli:test --no-daemon`
- `gradle build --no-daemon` *(fails: Execution failed for task ':intellij:test')*

------
https://chatgpt.com/codex/tasks/task_b_686e31bceca4832a813d11755e72f848