### PR TITLE
FEAT-IJ-004: Embedded HTTP server

### DIFF
--- a/intellij/src/main/java/tech/softwareologists/ij/StartupActivity.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/StartupActivity.java
@@ -6,6 +6,9 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.psi.PsiManager;
 import com.intellij.openapi.Disposable;
 import tech.softwareologists.core.db.EmbeddedNeo4j;
+import tech.softwareologists.core.QueryService;
+import tech.softwareologists.core.QueryServiceImpl;
+import tech.softwareologists.ij.server.HttpMcpServer;
 
 /**
  * Project-level startup activity that logs when a project is opened.
@@ -27,6 +30,11 @@ public class StartupActivity implements com.intellij.openapi.startup.StartupActi
                     new PsiClassChangeListener(project, service),
                     (Disposable) project
             );
+
+            QueryService queryService = new QueryServiceImpl(db.getDriver());
+            HttpMcpServer server = new HttpMcpServer(0, queryService);
+            server.start();
+            LOG.info("MCP HTTP server started on port " + server.getPort());
         } catch (Exception e) {
             LOG.warn("Failed to import project classes", e);
         }

--- a/intellij/src/main/java/tech/softwareologists/ij/server/HttpMcpServer.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/server/HttpMcpServer.java
@@ -1,0 +1,97 @@
+package tech.softwareologists.ij.server;
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpExchange;
+import tech.softwareologists.core.ManifestGenerator;
+import tech.softwareologists.core.QueryService;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Minimal HTTP server exposing MCP endpoints.
+ */
+public class HttpMcpServer {
+    private static final Pattern FIND_CALLERS =
+            Pattern.compile("\\\"findCallers\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+
+    private final HttpServer server;
+    private final QueryService queryService;
+
+    public HttpMcpServer(int port, QueryService queryService) throws IOException {
+        this.queryService = queryService;
+        this.server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/mcp/manifest", new ManifestHandler());
+        server.createContext("/mcp/query", new QueryHandler());
+    }
+
+    /** Starts the server. */
+    public void start() {
+        server.start();
+    }
+
+    /** Stops the server. */
+    public void stop() {
+        server.stop(0);
+    }
+
+    /** Returns the bound port. */
+    public int getPort() {
+        return server.getAddress().getPort();
+    }
+
+    private class ManifestHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            byte[] bytes = ManifestGenerator.generate().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        }
+    }
+
+    private class QueryHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            String response;
+            Matcher m = FIND_CALLERS.matcher(body);
+            if (m.find()) {
+                String cls = m.group(1);
+                List<String> callers = queryService.findCallers(cls);
+                StringBuilder sb = new StringBuilder();
+                sb.append('[');
+                for (int i = 0; i < callers.size(); i++) {
+                    if (i > 0) sb.append(',');
+                    sb.append('"').append(callers.get(i)).append('"');
+                }
+                sb.append(']');
+                response = sb.toString();
+            } else {
+                response = "[]";
+            }
+            byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        }
+    }
+}

--- a/intellij/src/test/java/tech/softwareologists/ij/HttpMcpServerTest.java
+++ b/intellij/src/test/java/tech/softwareologists/ij/HttpMcpServerTest.java
@@ -1,0 +1,44 @@
+package tech.softwareologists.ij;
+
+import org.junit.Test;
+import tech.softwareologists.core.ManifestGenerator;
+import tech.softwareologists.core.QueryService;
+import tech.softwareologists.ij.server.HttpMcpServer;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+public class HttpMcpServerTest {
+    @Test
+    public void manifestAndQuery_returnJson() throws Exception {
+        QueryService qs = cls -> Collections.singletonList("Caller");
+        HttpMcpServer server = new HttpMcpServer(0, qs);
+        server.start();
+        int port = server.getPort();
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest manifestReq = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:" + port + "/mcp/manifest"))
+                .GET()
+                .build();
+        HttpResponse<String> manifestResp = client.send(manifestReq, HttpResponse.BodyHandlers.ofString());
+        if (!manifestResp.body().equals(ManifestGenerator.generate())) {
+            throw new AssertionError("Manifest mismatch: " + manifestResp.body());
+        }
+
+        HttpRequest queryReq = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:" + port + "/mcp/query"))
+                .POST(HttpRequest.BodyPublishers.ofString("{\"findCallers\":\"X\"}"))
+                .header("Content-Type", "application/json")
+                .build();
+        HttpResponse<String> queryResp = client.send(queryReq, HttpResponse.BodyHandlers.ofString());
+        if (!queryResp.body().equals("[\"Caller\"]")) {
+            throw new AssertionError("Unexpected query response: " + queryResp.body());
+        }
+        server.stop();
+    }
+}


### PR DESCRIPTION
## Summary
- add `HttpMcpServer` with `/mcp/manifest` and `/mcp/query`
- launch server from `StartupActivity`
- test server endpoints

## Testing
- `gradle spotlessApply`
- `gradle :intellij:test`
- `gradle :core:test`


------
https://chatgpt.com/codex/tasks/task_b_686ecf653834832a980701fbee5e7017