### PR TITLE
FEAT-IJ-005: configurable MCP settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ imports a sample JAR, and executes a query.
    * Select `intellij/build/distributions/intellij-*.zip`.
 2. **Configure**
 
-   * Open *Settings > Tools > CodeGraph MCP* and set the HTTP port.
+   * Open *Settings > Tools > CodeGraph MCP* and set the HTTP port and optional package filters.
 3. **Use**
 
    * On project open, the plugin scans classes and exposes `/mcp/manifest` and `/mcp/query`.

--- a/intellij/resources/META-INF/plugin.xml
+++ b/intellij/resources/META-INF/plugin.xml
@@ -8,5 +8,10 @@
     <depends>com.intellij.modules.platform</depends>
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="tech.softwareologists.ij.StartupActivity"/>
+        <applicationConfigurable
+                id="tech.softwareologists.codegraph.settings"
+                groupId="tools"
+                displayName="CodeGraph MCP"
+                implementation="tech.softwareologists.ij.settings.McpSettingsConfigurable"/>
     </extensions>
 </idea-plugin>

--- a/intellij/src/main/java/tech/softwareologists/ij/PsiClassImportService.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/PsiClassImportService.java
@@ -21,9 +21,32 @@ import java.util.Collection;
  */
 public class PsiClassImportService {
     private final Driver driver;
+    private final java.util.Set<String> filters;
 
-    public PsiClassImportService(Driver driver) {
+    public PsiClassImportService(Driver driver, String filterString) {
         this.driver = driver;
+        this.filters = parseFilters(filterString);
+    }
+
+    private static java.util.Set<String> parseFilters(String filterString) {
+        java.util.Set<String> set = new java.util.HashSet<>();
+        if (filterString != null && !filterString.isBlank()) {
+            for (String part : filterString.split(",")) {
+                String trimmed = part.trim();
+                if (!trimmed.isEmpty()) {
+                    set.add(trimmed);
+                }
+            }
+        }
+        return set;
+    }
+
+    private boolean allowed(String qname) {
+        if (filters.isEmpty()) return true;
+        for (String f : filters) {
+            if (qname.startsWith(f)) return true;
+        }
+        return false;
     }
 
     /**
@@ -44,7 +67,7 @@ public class PsiClassImportService {
                     PsiClass[] classes = ((PsiJavaFile) file).getClasses();
                     for (PsiClass cls : classes) {
                         String qname = cls.getQualifiedName();
-                        if (qname != null) {
+                        if (qname != null && allowed(qname)) {
                             session.run("MERGE (c:" + NodeLabel.CLASS + " {name:$name})",
                                     Values.parameters("name", qname));
                             count++;
@@ -63,7 +86,7 @@ public class PsiClassImportService {
      */
     public void importPsiClass(PsiClass cls) {
         String qname = cls.getQualifiedName();
-        if (qname == null) {
+        if (qname == null || !allowed(qname)) {
             return;
         }
         try (Session session = driver.session()) {

--- a/intellij/src/main/java/tech/softwareologists/ij/StartupActivity.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/StartupActivity.java
@@ -9,6 +9,7 @@ import tech.softwareologists.core.db.EmbeddedNeo4j;
 import tech.softwareologists.core.QueryService;
 import tech.softwareologists.core.QueryServiceImpl;
 import tech.softwareologists.ij.server.HttpMcpServer;
+import tech.softwareologists.ij.settings.McpSettings;
 
 /**
  * Project-level startup activity that logs when a project is opened.
@@ -23,7 +24,8 @@ public class StartupActivity implements com.intellij.openapi.startup.StartupActi
 
         try {
             EmbeddedNeo4j db = new EmbeddedNeo4j();
-            PsiClassImportService service = new PsiClassImportService(db.getDriver());
+            McpSettings settings = McpSettings.getInstance();
+            PsiClassImportService service = new PsiClassImportService(db.getDriver(), settings.getPackageFilters());
             int count = service.importProjectClasses(project);
             LOG.info("Imported " + count + " classes from project");
             PsiManager.getInstance(project).addPsiTreeChangeListener(
@@ -32,7 +34,7 @@ public class StartupActivity implements com.intellij.openapi.startup.StartupActi
             );
 
             QueryService queryService = new QueryServiceImpl(db.getDriver());
-            HttpMcpServer server = new HttpMcpServer(0, queryService);
+            HttpMcpServer server = new HttpMcpServer(settings.getPort(), queryService);
             server.start();
             LOG.info("MCP HTTP server started on port " + server.getPort());
         } catch (Exception e) {

--- a/intellij/src/main/java/tech/softwareologists/ij/settings/McpSettings.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/settings/McpSettings.java
@@ -1,0 +1,42 @@
+package tech.softwareologists.ij.settings;
+
+import com.intellij.ide.util.PropertiesComponent;
+
+/**
+ * Accessor for persistent MCP plugin settings.
+ */
+public class McpSettings {
+    private static final String PORT_KEY = "codegraph.mcp.port";
+    private static final String FILTERS_KEY = "codegraph.mcp.packageFilters";
+
+    private final PropertiesComponent props = PropertiesComponent.getInstance();
+
+    /** Returns the configured HTTP port or 9090 by default. */
+    public int getPort() {
+        return props.getInt(PORT_KEY, 9090);
+    }
+
+    /** Sets the HTTP port. */
+    public void setPort(int port) {
+        props.setValue(PORT_KEY, String.valueOf(port));
+    }
+
+    /** Returns comma-separated package filters. */
+    public String getPackageFilters() {
+        return props.getValue(FILTERS_KEY, "");
+    }
+
+    /** Sets comma-separated package filters. */
+    public void setPackageFilters(String filters) {
+        props.setValue(FILTERS_KEY, filters == null ? "" : filters);
+    }
+
+    /** Singleton instance. */
+    public static McpSettings getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    private static class Holder {
+        private static final McpSettings INSTANCE = new McpSettings();
+    }
+}

--- a/intellij/src/main/java/tech/softwareologists/ij/settings/McpSettingsConfigurable.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/settings/McpSettingsConfigurable.java
@@ -1,0 +1,82 @@
+package tech.softwareologists.ij.settings;
+
+import com.intellij.openapi.options.Configurable;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Settings panel allowing configuration of the MCP HTTP port and package filters.
+ */
+public class McpSettingsConfigurable implements Configurable {
+    private JTextField portField;
+    private JTextField filterField;
+    private JPanel panel;
+
+    @Override
+    public @Nls String getDisplayName() {
+        return "CodeGraph MCP";
+    }
+
+    @Override
+    public @Nullable JComponent createComponent() {
+        panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gc = new GridBagConstraints();
+        gc.insets = new Insets(4,4,4,4);
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.gridx = 0;
+        gc.gridy = 0;
+        panel.add(new JLabel("HTTP Port:"), gc);
+        gc.gridx = 1;
+        portField = new JTextField(String.valueOf(McpSettings.getInstance().getPort()), 10);
+        panel.add(portField, gc);
+
+        gc.gridx = 0;
+        gc.gridy = 1;
+        panel.add(new JLabel("Package Filters (comma-separated):"), gc);
+        gc.gridx = 1;
+        filterField = new JTextField(McpSettings.getInstance().getPackageFilters(), 20);
+        panel.add(filterField, gc);
+        return panel;
+    }
+
+    @Override
+    public boolean isModified() {
+        McpSettings settings = McpSettings.getInstance();
+        String portText = portField.getText().trim();
+        String filterText = filterField.getText().trim();
+        return settings.getPort() != parseInt(portText, settings.getPort()) ||
+                !filterText.equals(settings.getPackageFilters());
+    }
+
+    @Override
+    public void apply() {
+        McpSettings settings = McpSettings.getInstance();
+        settings.setPort(parseInt(portField.getText().trim(), settings.getPort()));
+        settings.setPackageFilters(filterField.getText().trim());
+    }
+
+    private static int parseInt(String text, int def) {
+        try {
+            return Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            return def;
+        }
+    }
+
+    @Override
+    public void reset() {
+        McpSettings settings = McpSettings.getInstance();
+        portField.setText(String.valueOf(settings.getPort()));
+        filterField.setText(settings.getPackageFilters());
+    }
+
+    @Override
+    public void disposeUIResources() {
+        panel = null;
+        portField = null;
+        filterField = null;
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable HTTP port and package filter UI
- persist settings via `PropertiesComponent`
- apply settings when starting server

## Testing
- `gradle spotlessApply`
- `gradle :core:test :cli:test :intellij:buildPlugin spotlessCheck`


------
https://chatgpt.com/codex/tasks/task_b_686ed9b02b08832aa1f3ecde43c9a4e5