### PR TITLE
Add GitHub pages docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,47 @@
+<!-- markdownlint-disable MD025 MD041 MD003 MD022 -->
+---
+layout: default
+title: CodeGraph MCP Server
+---
+
+# CodeGraph MCP Server
+
+A multi-module project that indexes Java class dependencies and exposes them
+via the MCP protocol.
+
+## Modules
+
+### Core
+
+- Imports JAR files and discovers classes with **ClassGraph**.
+- Persists classes and their dependencies to an embedded **Neo4j** database.
+- Provides `QueryService` with methods such as `findCallers`.
+- Generates an MCP manifest through `ManifestGenerator`.
+
+### CLI
+
+- `CliMain` parses command line options to watch directories or project paths.
+- `JarWatcher` detects new JAR files and triggers imports.
+- `StdioMcpServer` responds to manifest and query requests over STDIO.
+- `ProjectDirWatcher` and `ProjectDirImporter` handle full project imports.
+- Packaged as a standalone fat JAR using the `shadowJar` task.
+
+### IntelliJ
+
+- `StartupActivity` scans the project when the IDE opens.
+- `PsiClassImportService` collects PSI classes for indexing.
+- `PsiClassChangeListener` updates the graph on file changes.
+- `HttpMcpServer` exposes `/mcp/manifest` and `/mcp/query` over HTTP.
+- A settings panel allows configuring port and package filters.
+
+## Running Module Tests
+
+Run tests for each module individually with Gradle:
+
+```bash
+./gradlew :core:test
+./gradlew :cli:test
+./gradlew :intellij:test
+```
+
+For a full build of all modules use `./gradlew build`.


### PR DESCRIPTION
## Summary
- create `docs` folder with Jekyll theme
- describe core, cli and IntelliJ modules
- document how to run module tests individually

## Testing
- `markdownlint docs/index.md README.md Task_breakdown.md ProjectPlan.md examples/sample-idea/README.md`
- `gradle spotlessApply`


------
https://chatgpt.com/codex/tasks/task_b_686ee2098574832a95c977640bf5e1c5