### PR TITLE
FEAT-DOC-003: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Generate Gradle Wrapper
+        run: gradle wrapper --gradle-version 8.5 --distribution-type all --console=plain
+      - name: Build Project
+        run: ./gradlew build :intellij:buildPlugin --no-daemon --console=plain

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CodeGraph MCP Server for Java applications(java-codegraph-mcp-server)
 
+[![Build Status](https://github.com/<your-org>/java-codegraph-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-org>/java-codegraph-mcp-server/actions/workflows/ci.yml)
+
 A Java-based multi-module project that uses ClassGraph to scan JARs (and IntelliJ PSI), persists the resulting class-dependency graph in an embedded Neo4j database, and exposes it over the MCP protocol via both a CLI folder-watcher and an IntelliJ plugin.
 
 ## Features
@@ -44,6 +46,10 @@ java-codegraph-mcp-server/
    ```bash
    ./gradlew :core:test
    ```
+## Continuous Integration
+
+The project is built and tested on every push using [GitHub Actions](https://github.com/<your-org>/java-codegraph-mcp-server/actions). The pipeline executes `./gradlew build` and `:intellij:buildPlugin` in a headless environment.
+
 
 ## CLI Usage
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `./gradlew build` and plugin build
- document CI badge and explain workflow in README

## Testing
- `./gradlew :core:test :cli:test :intellij:buildPlugin spotlessCheck --console=plain`


------
https://chatgpt.com/codex/tasks/task_b_686eea78b9d4832ab9af1b004909f256