### PR TITLE
FEAT-CORE-009: add hierarchy relationships and queries

### DIFF
--- a/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
+++ b/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
@@ -62,6 +62,33 @@ public class ProjectDirImporter {
                                     "MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS + " {name:$tgt}) MERGE (s)-[:DEPENDS_ON]->(t)",
                                     Values.parameters("src", cls, "tgt", depName));
                         }
+
+                        // record implemented interfaces
+                        java.util.Set<String> seenInterfaces = new java.util.HashSet<>();
+                        for (ClassInfo iface : classInfo.getInterfaces()) {
+                            String ifaceName = iface.getName();
+                            if (!seenInterfaces.add(ifaceName)) {
+                                continue;
+                            }
+                            session.run(
+                                    "MERGE (i:" + NodeLabel.CLASS + " {name:$iface})",
+                                    Values.parameters("iface", ifaceName));
+                            session.run(
+                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (i:" + NodeLabel.CLASS + " {name:$iface}) MERGE (c)-[:IMPLEMENTS]->(i)",
+                                    Values.parameters("cls", cls, "iface", ifaceName));
+                        }
+
+                        // record superclass relationship
+                        ClassInfo superInfo = classInfo.getSuperclass();
+                        if (superInfo != null) {
+                            String superName = superInfo.getName();
+                            session.run(
+                                    "MERGE (s:" + NodeLabel.CLASS + " {name:$sup})",
+                                    Values.parameters("sup", superName));
+                            session.run(
+                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (s:" + NodeLabel.CLASS + " {name:$sup}) MERGE (c)-[:EXTENDS]->(s)",
+                                    Values.parameters("cls", cls, "sup", superName));
+                        }
                     }
                 }
                 LOGGER.info("Imported " + classes.size() + " classes");

--- a/cli/src/test/java/tech/softwareologists/cli/StdioMcpServerTest.java
+++ b/cli/src/test/java/tech/softwareologists/cli/StdioMcpServerTest.java
@@ -16,7 +16,22 @@ public class StdioMcpServerTest {
         ByteArrayInputStream in = new ByteArrayInputStream(request.getBytes(StandardCharsets.UTF_8));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        QueryService qs = className -> java.util.Collections.emptyList();
+        QueryService qs = new QueryService() {
+            @Override
+            public java.util.List<String> findCallers(String className) {
+                return java.util.Collections.emptyList();
+            }
+
+            @Override
+            public java.util.List<String> findImplementations(String interfaceName) {
+                return java.util.Collections.emptyList();
+            }
+
+            @Override
+            public java.util.List<String> findSubclasses(String className, int depth) {
+                return java.util.Collections.emptyList();
+            }
+        };
         new StdioMcpServer(qs, in, new PrintStream(out)).run();
 
         String output = out.toString(StandardCharsets.UTF_8);

--- a/core/manifest.json.tpl
+++ b/core/manifest.json.tpl
@@ -2,6 +2,8 @@
   "name": "CodeGraph MCP",
   "version": "0.1.0",
   "capabilities": [
-    { "name": "findCallers", "params": ["className"] }
+    { "name": "findCallers", "params": ["className"] },
+    { "name": "findImplementations", "params": ["interfaceName"] },
+    { "name": "findSubclasses", "params": ["className", "depth"] }
   ]
 }

--- a/core/src/main/java/tech/softwareologists/core/QueryService.java
+++ b/core/src/main/java/tech/softwareologists/core/QueryService.java
@@ -4,4 +4,8 @@ import java.util.List;
 
 public interface QueryService {
     List<String> findCallers(String className);
+
+    List<String> findImplementations(String interfaceName);
+
+    List<String> findSubclasses(String className, int depth);
 }

--- a/core/src/main/java/tech/softwareologists/core/QueryServiceImpl.java
+++ b/core/src/main/java/tech/softwareologists/core/QueryServiceImpl.java
@@ -26,4 +26,23 @@ public class QueryServiceImpl implements QueryService {
                     .list(r -> r.get("name").asString());
         }
     }
+
+    @Override
+    public List<String> findImplementations(String interfaceName) {
+        try (Session session = driver.session()) {
+            return session.run(
+                            "MATCH (c:" + NodeLabel.CLASS + ")-[:IMPLEMENTS]->(i:" + NodeLabel.CLASS + " {name:$name}) RETURN c.name AS name",
+                            Values.parameters("name", interfaceName))
+                    .list(r -> r.get("name").asString());
+        }
+    }
+
+    @Override
+    public List<String> findSubclasses(String className, int depth) {
+        try (Session session = driver.session()) {
+            String query = "MATCH (sub:" + NodeLabel.CLASS + ")-[:EXTENDS*1.." + depth + "]->(sup:" + NodeLabel.CLASS + " {name:$name}) RETURN DISTINCT sub.name AS name";
+            return session.run(query, Values.parameters("name", className))
+                    .list(r -> r.get("name").asString());
+        }
+    }
 }

--- a/core/src/test/java/tech/softwareologists/core/ManifestGeneratorTest.java
+++ b/core/src/test/java/tech/softwareologists/core/ManifestGeneratorTest.java
@@ -9,5 +9,11 @@ public class ManifestGeneratorTest {
         if (!manifest.contains("findCallers")) {
             throw new AssertionError("Manifest missing findCallers capability: " + manifest);
         }
+        if (!manifest.contains("findImplementations")) {
+            throw new AssertionError("Manifest missing findImplementations capability: " + manifest);
+        }
+        if (!manifest.contains("findSubclasses")) {
+            throw new AssertionError("Manifest missing findSubclasses capability: " + manifest);
+        }
     }
 }

--- a/core/src/test/java/tech/softwareologists/core/QueryServiceImplTest.java
+++ b/core/src/test/java/tech/softwareologists/core/QueryServiceImplTest.java
@@ -26,4 +26,91 @@ public class QueryServiceImplTest {
             }
         }
     }
+
+    @Test
+    public void findImplementations_interfaceWithTwoClasses_returnsBoth() throws Exception {
+        java.nio.file.Path src = java.nio.file.Files.createTempDirectory("implsrc");
+        java.nio.file.Path pkg = src.resolve("impl");
+        java.nio.file.Files.createDirectories(pkg);
+        java.nio.file.Path iface = pkg.resolve("MyIntf.java");
+        java.nio.file.Files.write(iface, "package impl; public interface MyIntf {}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        java.nio.file.Path c1 = pkg.resolve("ImplA.java");
+        java.nio.file.Files.write(c1, "package impl; public class ImplA implements MyIntf {}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        java.nio.file.Path c2 = pkg.resolve("ImplB.java");
+        java.nio.file.Files.write(c2, "package impl; public class ImplB implements MyIntf {}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        javax.tools.JavaCompiler compiler = javax.tools.ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) throw new IllegalStateException("Java compiler not available");
+        int res = compiler.run(null, null, null, iface.toString(), c1.toString(), c2.toString());
+        if (res != 0) throw new IllegalStateException("Compilation failed");
+
+        java.io.File jar = java.io.File.createTempFile("impl", ".jar");
+        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(new java.io.FileOutputStream(jar))) {
+            for (String n : new String[]{"impl/MyIntf.class", "impl/ImplA.class", "impl/ImplB.class"}) {
+                jos.putNextEntry(new java.util.jar.JarEntry(n));
+                java.nio.file.Files.copy(pkg.resolve(n.substring(n.lastIndexOf('/') + 1)), jos);
+                jos.closeEntry();
+            }
+        }
+
+        try (EmbeddedNeo4j db = new EmbeddedNeo4j()) {
+            Driver driver = db.getDriver();
+            JarImporter.importJar(jar, driver);
+
+            QueryService service = new QueryServiceImpl(driver);
+            java.util.List<String> impls = service.findImplementations("impl.MyIntf");
+            java.util.Set<String> expected = new java.util.HashSet<>();
+            expected.add("impl.ImplA");
+            expected.add("impl.ImplB");
+            if (!impls.containsAll(expected) || impls.size() != 2) {
+                throw new AssertionError("Unexpected implementations: " + impls);
+            }
+        }
+    }
+
+    @Test
+    public void findSubclasses_hierarchy_respectsDepth() throws Exception {
+        java.nio.file.Path src = java.nio.file.Files.createTempDirectory("subsrc");
+        java.nio.file.Path pkg = src.resolve("hier");
+        java.nio.file.Files.createDirectories(pkg);
+        java.nio.file.Path base = pkg.resolve("Base.java");
+        java.nio.file.Files.write(base, "package hier; public class Base {}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        java.nio.file.Path mid = pkg.resolve("Mid.java");
+        java.nio.file.Files.write(mid, "package hier; public class Mid extends Base {}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        java.nio.file.Path leaf = pkg.resolve("Leaf.java");
+        java.nio.file.Files.write(leaf, "package hier; public class Leaf extends Mid {}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        javax.tools.JavaCompiler compiler = javax.tools.ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) throw new IllegalStateException("Java compiler not available");
+        int res = compiler.run(null, null, null, base.toString(), mid.toString(), leaf.toString());
+        if (res != 0) throw new IllegalStateException("Compilation failed");
+
+        java.io.File jar = java.io.File.createTempFile("subs", ".jar");
+        try (java.util.jar.JarOutputStream jos = new java.util.jar.JarOutputStream(new java.io.FileOutputStream(jar))) {
+            for (String n : new String[]{"hier/Base.class", "hier/Mid.class", "hier/Leaf.class"}) {
+                jos.putNextEntry(new java.util.jar.JarEntry(n));
+                java.nio.file.Files.copy(pkg.resolve(n.substring(n.lastIndexOf('/') + 1)), jos);
+                jos.closeEntry();
+            }
+        }
+
+        try (EmbeddedNeo4j db = new EmbeddedNeo4j()) {
+            Driver driver = db.getDriver();
+            JarImporter.importJar(jar, driver);
+
+            QueryService service = new QueryServiceImpl(driver);
+            java.util.List<String> depth1 = service.findSubclasses("hier.Base", 1);
+            if (depth1.size() != 1 || !depth1.get(0).equals("hier.Mid")) {
+                throw new AssertionError("Unexpected depth1 result: " + depth1);
+            }
+
+            java.util.List<String> depth2 = service.findSubclasses("hier.Base", 2);
+            java.util.Set<String> expected = new java.util.HashSet<>();
+            expected.add("hier.Mid");
+            expected.add("hier.Leaf");
+            if (!depth2.containsAll(expected) || depth2.size() != 2) {
+                throw new AssertionError("Unexpected depth2 result: " + depth2);
+            }
+        }
+    }
 }

--- a/intellij/src/test/java/tech/softwareologists/ij/HttpMcpServerTest.java
+++ b/intellij/src/test/java/tech/softwareologists/ij/HttpMcpServerTest.java
@@ -15,7 +15,22 @@ import java.util.Collections;
 public class HttpMcpServerTest {
     @Test
     public void manifestAndQuery_returnJson() throws Exception {
-        QueryService qs = cls -> Collections.singletonList("Caller");
+        QueryService qs = new QueryService() {
+            @Override
+            public java.util.List<String> findCallers(String className) {
+                return java.util.Collections.singletonList("Caller");
+            }
+
+            @Override
+            public java.util.List<String> findImplementations(String interfaceName) {
+                return java.util.Collections.emptyList();
+            }
+
+            @Override
+            public java.util.List<String> findSubclasses(String className, int depth) {
+                return java.util.Collections.emptyList();
+            }
+        };
         HttpMcpServer server = new HttpMcpServer(0, qs);
         server.start();
         int port = server.getPort();


### PR DESCRIPTION
## Summary
- record IMPLEMENTS and EXTENDS edges during imports
- expose `findImplementations` and `findSubclasses` query APIs
- update manifest template and tests
- adapt CLI test to new QueryService interface

## Testing
- `gradle spotlessApply`
- `gradle :core:test`
- `gradle :cli:test`


------
https://chatgpt.com/codex/tasks/task_b_686ef20161e4832a8e1d9d4f1e4c8201