### PR TITLE
FEAT-CORE-010: import methods and calls

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -12,6 +12,7 @@ java {
 
 dependencies {
     implementation("io.github.classgraph:classgraph:4.8.180")
+    implementation("org.ow2.asm:asm:9.7")
     implementation("org.neo4j.test:neo4j-harness:5.19.0")
     api("org.neo4j.driver:neo4j-java-driver:5.19.0")
 }


### PR DESCRIPTION
## Summary
- create method nodes with bytecode via ASM
- merge CALLS edges from bytecode
- add ASM dependency
- test method call import

## Testing
- `gradle :core:test`
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_b_686f16b6d4fc832aa8f652e17276df5b