### PR TITLE
FEAT-CLI-001: parse methods in project directories

### DIFF
--- a/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
+++ b/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
@@ -6,10 +6,18 @@ import io.github.classgraph.ScanResult;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Values;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import tech.softwareologists.core.db.NodeLabel;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -48,6 +56,54 @@ public class ProjectDirImporter {
                         session.run(
                                 "MERGE (c:" + NodeLabel.CLASS + " {name:$name})",
                                 Values.parameters("name", cls));
+
+                        // parse bytecode to create method nodes and call edges
+                        List<String> methodNames = new java.util.ArrayList<>();
+                        Map<String, Set<String>> calls = new HashMap<>();
+                        try (java.io.InputStream in = classInfo.getResource().open()) {
+                            ClassReader cr = new ClassReader(in);
+                            cr.accept(new ClassVisitor(Opcodes.ASM9) {
+                                @Override
+                                public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                                    String sig = name + descriptor;
+                                    methodNames.add(sig);
+                                    session.run(
+                                            "MERGE (m:" + NodeLabel.METHOD + " {class:$cls, signature:$sig})",
+                                            Values.parameters("cls", cls, "sig", sig));
+                                    return new MethodVisitor(Opcodes.ASM9) {
+                                        @Override
+                                        public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                                            String tgtCls = owner.replace('/', '.');
+                                            String tgtSig = name + descriptor;
+                                            calls.computeIfAbsent(sig, k -> new HashSet<>()).add(tgtCls + "|" + tgtSig);
+                                        }
+                                    };
+                                }
+                            }, 0);
+                        }
+                        if (!methodNames.isEmpty()) {
+                            LOGGER.info("Methods in " + cls + ": " + methodNames);
+                        }
+
+                        for (Map.Entry<String, Set<String>> entry : calls.entrySet()) {
+                            String fromSig = entry.getKey();
+                            for (String tgtCombined : entry.getValue()) {
+                                int idx = tgtCombined.indexOf('|');
+                                String tgtCls = tgtCombined.substring(0, idx);
+                                String tgtSig = tgtCombined.substring(idx + 1);
+                                session.run(
+                                        "MERGE (m:" + NodeLabel.METHOD + " {class:$cls, signature:$sig})",
+                                        Values.parameters("cls", tgtCls, "sig", tgtSig));
+                                session.run(
+                                        "MATCH (s:" + NodeLabel.METHOD + " {class:$scls, signature:$ssig}), " +
+                                                "(t:" + NodeLabel.METHOD + " {class:$tcls, signature:$tsig}) MERGE (s)-[:CALLS]->(t)",
+                                        Values.parameters(
+                                                "scls", cls,
+                                                "ssig", fromSig,
+                                                "tcls", tgtCls,
+                                                "tsig", tgtSig));
+                            }
+                        }
 
                         java.util.Set<String> seenDeps = new java.util.HashSet<>();
                         for (ClassInfo dep : classInfo.getClassDependencies()) {

--- a/cli/src/test/java/tech/softwareologists/cli/ProjectDirImporterTest.java
+++ b/cli/src/test/java/tech/softwareologists/cli/ProjectDirImporterTest.java
@@ -9,7 +9,6 @@ import tech.softwareologists.core.db.NodeLabel;
 
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,6 +45,42 @@ public class ProjectDirImporterTest {
                 List<Record> result = session.run("MATCH (c:" + NodeLabel.CLASS + " {name:'foo.Bar'}) RETURN c").list();
                 if (result.isEmpty()) {
                     throw new AssertionError("Node foo.Bar not persisted");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void importDir_methodCall_createsEdge() throws Exception {
+        Path srcDir = Files.createTempDirectory("srcmethoddir");
+        Path pkgDir = srcDir.resolve("calls");
+        Files.createDirectories(pkgDir);
+        Path calleeFile = pkgDir.resolve("Callee.java");
+        Files.write(calleeFile, "package calls; public class Callee { public void m() {} }".getBytes(StandardCharsets.UTF_8));
+        Path callerFile = pkgDir.resolve("Caller.java");
+        Files.write(callerFile, "package calls; public class Caller { public void n() { new Callee().m(); } }".getBytes(StandardCharsets.UTF_8));
+
+        Path outDir = Files.createTempDirectory("methodclasses");
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new IllegalStateException("Java compiler not available");
+        }
+        int res = compiler.run(null, null, null, "-d", outDir.toString(), calleeFile.toString(), callerFile.toString());
+        if (res != 0) {
+            throw new IllegalStateException("Compilation failed");
+        }
+
+        try (EmbeddedNeo4j db = new EmbeddedNeo4j()) {
+            Driver driver = db.getDriver();
+            ProjectDirImporter.importDirectory(outDir.toFile(), driver);
+
+            try (Session session = driver.session()) {
+                List<Record> rel = session.run(
+                        "MATCH (s:" + NodeLabel.METHOD + " {class:'calls.Caller', signature:'n()V'})-[:CALLS]->(t:" + NodeLabel.METHOD + " {class:'calls.Callee', signature:'m()V'}) RETURN t")
+                        .list();
+                if (rel.isEmpty()) {
+                    throw new AssertionError("CALLS edge not created");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- extract method nodes and CALLS edges when importing compiled project directories
- add regression test for method call handling

## Testing
- `gradle :cli:test`
- `gradle build`
- `gradle spotlessCheck`


------
https://chatgpt.com/codex/tasks/task_b_686f1e22ffe0832aa2cbbbd8e41eeb4b