### PR TITLE
FEAT-CORE-007: update manifest for new QueryService methods

### DIFF
--- a/core/manifest.json.tpl
+++ b/core/manifest.json.tpl
@@ -10,8 +10,13 @@
     { "name": "findMethodsCallingMethod", "params": ["className", "methodSignature", "limit"] },
     { "name": "findBeansWithAnnotation", "params": ["annotation"] },
     { "name": "searchByAnnotation", "params": ["annotation", "targetType"] },
+    { "name": "findHttpEndpoints", "params": ["basePath", "httpMethod"] },
     { "name": "findControllersUsingService", "params": ["serviceClassName"] },
+    { "name": "findEventListeners", "params": ["eventType"] },
+    { "name": "findScheduledTasks", "params": [] },
+    { "name": "findConfigPropertyUsage", "params": ["propertyKey"] },
     { "name": "getPackageHierarchy", "params": ["rootPackage", "depth"] },
+    { "name": "getGraphStatistics", "params": ["topN"] },
     { "name": "exportGraph", "params": ["format", "outputPath"] }
   ]
 }

--- a/core/src/test/java/tech/softwareologists/core/ManifestGeneratorTest.java
+++ b/core/src/test/java/tech/softwareologists/core/ManifestGeneratorTest.java
@@ -30,11 +30,29 @@ public class ManifestGeneratorTest {
         if (!manifest.contains("searchByAnnotation")) {
             throw new AssertionError("Manifest missing searchByAnnotation capability: " + manifest);
         }
+        if (!manifest.contains("findHttpEndpoints")) {
+            throw new AssertionError("Manifest missing findHttpEndpoints capability: " + manifest);
+        }
         if (!manifest.contains("findControllersUsingService")) {
             throw new AssertionError("Manifest missing findControllersUsingService capability: " + manifest);
         }
+        if (!manifest.contains("findEventListeners")) {
+            throw new AssertionError("Manifest missing findEventListeners capability: " + manifest);
+        }
+        if (!manifest.contains("findScheduledTasks")) {
+            throw new AssertionError("Manifest missing findScheduledTasks capability: " + manifest);
+        }
+        if (!manifest.contains("findConfigPropertyUsage")) {
+            throw new AssertionError("Manifest missing findConfigPropertyUsage capability: " + manifest);
+        }
         if (!manifest.contains("getPackageHierarchy")) {
             throw new AssertionError("Manifest missing getPackageHierarchy capability: " + manifest);
+        }
+        if (!manifest.contains("getGraphStatistics")) {
+            throw new AssertionError("Manifest missing getGraphStatistics capability: " + manifest);
+        }
+        if (!manifest.contains("exportGraph")) {
+            throw new AssertionError("Manifest missing exportGraph capability: " + manifest);
         }
     }
 }


### PR DESCRIPTION
## Summary
- list all capabilities in manifest.json.tpl
- assert all capability names in ManifestGeneratorTest

## Testing
- `gradle :core:test --tests "*ManifestGeneratorTest" --console=plain`
- `gradle spotlessApply`

------
https://chatgpt.com/codex/tasks/task_b_68709212e8c4832ab7b0658cd433bd29