### PR TITLE
FEAT-CORE-005: Add edge type enums

### DIFF
--- a/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
+++ b/cli/src/main/java/tech/softwareologists/cli/ProjectDirImporter.java
@@ -11,6 +11,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import tech.softwareologists.core.db.NodeLabel;
+import tech.softwareologists.core.db.EdgeType;
 
 import java.io.File;
 import java.util.List;
@@ -115,7 +116,7 @@ public class ProjectDirImporter {
                                     "MERGE (d:" + NodeLabel.CLASS + " {name:$dep})",
                                     Values.parameters("dep", depName));
                             session.run(
-                                    "MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS + " {name:$tgt}) MERGE (s)-[:DEPENDS_ON]->(t)",
+                                    "MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS + " {name:$tgt}) MERGE (s)-[:" + EdgeType.DEPENDS_ON + "]->(t)",
                                     Values.parameters("src", cls, "tgt", depName));
                         }
 
@@ -130,7 +131,7 @@ public class ProjectDirImporter {
                                     "MERGE (i:" + NodeLabel.CLASS + " {name:$iface})",
                                     Values.parameters("iface", ifaceName));
                             session.run(
-                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (i:" + NodeLabel.CLASS + " {name:$iface}) MERGE (c)-[:IMPLEMENTS]->(i)",
+                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (i:" + NodeLabel.CLASS + " {name:$iface}) MERGE (c)-[:" + EdgeType.IMPLEMENTS + "]->(i)",
                                     Values.parameters("cls", cls, "iface", ifaceName));
                         }
 
@@ -142,7 +143,7 @@ public class ProjectDirImporter {
                                     "MERGE (s:" + NodeLabel.CLASS + " {name:$sup})",
                                     Values.parameters("sup", superName));
                             session.run(
-                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (s:" + NodeLabel.CLASS + " {name:$sup}) MERGE (c)-[:EXTENDS]->(s)",
+                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (s:" + NodeLabel.CLASS + " {name:$sup}) MERGE (c)-[:" + EdgeType.EXTENDS + "]->(s)",
                                     Values.parameters("cls", cls, "sup", superName));
                         }
                     }

--- a/core/src/main/java/tech/softwareologists/core/JarImporter.java
+++ b/core/src/main/java/tech/softwareologists/core/JarImporter.java
@@ -14,6 +14,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Values;
 import tech.softwareologists.core.db.NodeLabel;
+import tech.softwareologists.core.db.EdgeType;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
@@ -422,7 +423,7 @@ public class JarImporter {
                                     "MERGE (d:" + NodeLabel.CLASS + " {name:$dep})",
                                     Values.parameters("dep", depName));
                             session.run(
-                                    "MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS + " {name:$tgt}) MERGE (s)-[:DEPENDS_ON]->(t)",
+                                    "MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS + " {name:$tgt}) MERGE (s)-[:" + EdgeType.DEPENDS_ON + "]->(t)",
                                     Values.parameters("src", cls, "tgt", depName));
                         }
 
@@ -431,7 +432,7 @@ public class JarImporter {
                                     "MERGE (u:" + NodeLabel.CLASS + " {name:$dep})",
                                     Values.parameters("dep", use));
                             session.run(
-                                    "MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS + " {name:$tgt}) MERGE (s)-[:USES]->(t)",
+                                    "MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS + " {name:$tgt}) MERGE (s)-[:" + EdgeType.USES + "]->(t)",
                                     Values.parameters("src", cls, "tgt", use));
                         }
 
@@ -446,7 +447,7 @@ public class JarImporter {
                                     "MERGE (i:" + NodeLabel.CLASS + " {name:$iface})",
                                     Values.parameters("iface", ifaceName));
                             session.run(
-                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (i:" + NodeLabel.CLASS + " {name:$iface}) MERGE (c)-[:IMPLEMENTS]->(i)",
+                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (i:" + NodeLabel.CLASS + " {name:$iface}) MERGE (c)-[:" + EdgeType.IMPLEMENTS + "]->(i)",
                                     Values.parameters("cls", cls, "iface", ifaceName));
                         }
 
@@ -458,7 +459,7 @@ public class JarImporter {
                                     "MERGE (s:" + NodeLabel.CLASS + " {name:$sup})",
                                     Values.parameters("sup", superName));
                             session.run(
-                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (s:" + NodeLabel.CLASS + " {name:$sup}) MERGE (c)-[:EXTENDS]->(s)",
+                                    "MATCH (c:" + NodeLabel.CLASS + " {name:$cls}), (s:" + NodeLabel.CLASS + " {name:$sup}) MERGE (c)-[:" + EdgeType.EXTENDS + "]->(s)",
                                     Values.parameters("cls", cls, "sup", superName));
                         }
                     }

--- a/core/src/main/java/tech/softwareologists/core/db/EdgeType.java
+++ b/core/src/main/java/tech/softwareologists/core/db/EdgeType.java
@@ -7,7 +7,23 @@ public enum EdgeType {
     /**
      * Represents a CALLS relationship between method nodes.
      */
-    CALLS;
+    CALLS,
+    /**
+     * Represents a DEPENDS_ON relationship between class nodes.
+     */
+    DEPENDS_ON,
+    /**
+     * Represents an IMPLEMENTS relationship between class and interface nodes.
+     */
+    IMPLEMENTS,
+    /**
+     * Represents an EXTENDS relationship between class nodes.
+     */
+    EXTENDS,
+    /**
+     * Represents a USES relationship where a class depends on a service bean.
+     */
+    USES;
 
     @Override
     public String toString() {

--- a/intellij/src/main/java/tech/softwareologists/ij/PsiClassImportService.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/PsiClassImportService.java
@@ -12,6 +12,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Values;
 import tech.softwareologists.core.db.NodeLabel;
+import tech.softwareologists.core.db.EdgeType;
 
 import java.util.Collection;
 
@@ -113,7 +114,7 @@ public class PsiClassImportService {
         session.run("MERGE (d:" + NodeLabel.CLASS + " {name:$dep})",
                 Values.parameters("dep", depName));
         session.run("MATCH (s:" + NodeLabel.CLASS + " {name:$src}), (t:" + NodeLabel.CLASS +
-                        " {name:$tgt}) MERGE (s)-[:DEPENDS_ON]->(t)",
+                        " {name:$tgt}) MERGE (s)-[:" + EdgeType.DEPENDS_ON + "]->(t)",
                 Values.parameters("src", src, "tgt", depName));
     }
 }


### PR DESCRIPTION
## Summary
- enumerate `DEPENDS_ON`, `IMPLEMENTS`, `EXTENDS`, and `USES` edge types
- use new `EdgeType` constants in core, CLI and IntelliJ importers
- update query implementation to use constants

## Testing
- `gradle :core:test`
- `gradle spotlessApply`


------
https://chatgpt.com/codex/tasks/task_b_6870c3f7e4ac832a845ed002e20a4460