### PR TITLE
FEAT-CORE-003: add paginated query results

### DIFF
--- a/cli/src/main/java/tech/softwareologists/cli/StdioMcpServer.java
+++ b/cli/src/main/java/tech/softwareologists/cli/StdioMcpServer.java
@@ -63,12 +63,12 @@ public class StdioMcpServer implements Runnable {
 
                 if (req.has("findCallers")) {
                     String cls = req.getString("findCallers");
-                    printArray(queryService.findCallers(cls));
+                    printArray(queryService.findCallers(cls, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("findImplementations")) {
                     String iface = req.getString("findImplementations");
-                    printArray(queryService.findImplementations(iface));
+                    printArray(queryService.findImplementations(iface, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("findSubclasses")) {
@@ -82,7 +82,7 @@ public class StdioMcpServer implements Runnable {
                     } else {
                         cls = val.toString();
                     }
-                    printArray(queryService.findSubclasses(cls, depth));
+                    printArray(queryService.findSubclasses(cls, depth, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("findDependencies")) {
@@ -96,7 +96,7 @@ public class StdioMcpServer implements Runnable {
                     } else {
                         cls = val.toString();
                     }
-                    printArray(queryService.findDependencies(cls, depth));
+                    printArray(queryService.findDependencies(cls, depth, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("findPathBetweenClasses")) {
@@ -104,7 +104,7 @@ public class StdioMcpServer implements Runnable {
                     String from = o.getString("fromClass");
                     String to = o.getString("toClass");
                     Integer max = o.has("maxDepth") ? o.getInt("maxDepth") : null;
-                    printArray(queryService.findPathBetweenClasses(from, to, max));
+                    printArray(queryService.findPathBetweenClasses(from, to, max).getItems());
                     continue;
                 }
                 if (req.has("findMethodsCallingMethod")) {
@@ -112,45 +112,45 @@ public class StdioMcpServer implements Runnable {
                     String cls = o.getString("className");
                     String sig = o.getString("methodSignature");
                     Integer lim = o.has("limit") ? o.getInt("limit") : null;
-                    printArray(queryService.findMethodsCallingMethod(cls, sig, lim));
+                    printArray(queryService.findMethodsCallingMethod(cls, sig, lim, null, null).getItems());
                     continue;
                 }
                 if (req.has("findBeansWithAnnotation")) {
                     String ann = req.getString("findBeansWithAnnotation");
-                    printArray(queryService.findBeansWithAnnotation(ann));
+                    printArray(queryService.findBeansWithAnnotation(ann, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("searchByAnnotation")) {
                     JSONObject o = req.getJSONObject("searchByAnnotation");
                     String ann = o.getString("annotation");
                     String target = o.optString("targetType", "class");
-                    printArray(queryService.searchByAnnotation(ann, target));
+                    printArray(queryService.searchByAnnotation(ann, target, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("findHttpEndpoints")) {
                     JSONObject o = req.getJSONObject("findHttpEndpoints");
                     String base = o.getString("basePath");
                     String verb = o.getString("httpMethod");
-                    printArray(queryService.findHttpEndpoints(base, verb));
+                    printArray(queryService.findHttpEndpoints(base, verb, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("findControllersUsingService")) {
                     String svc = req.getString("findControllersUsingService");
-                    printArray(queryService.findControllersUsingService(svc));
+                    printArray(queryService.findControllersUsingService(svc, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("findEventListeners")) {
                     String ev = req.getString("findEventListeners");
-                    printArray(queryService.findEventListeners(ev));
+                    printArray(queryService.findEventListeners(ev, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("findScheduledTasks")) {
-                    printArray(queryService.findScheduledTasks());
+                    printArray(queryService.findScheduledTasks(null, null, null).getItems());
                     continue;
                 }
                 if (req.has("findConfigPropertyUsage")) {
                     String key = req.getString("findConfigPropertyUsage");
-                    printArray(queryService.findConfigPropertyUsage(key));
+                    printArray(queryService.findConfigPropertyUsage(key, null, null, null).getItems());
                     continue;
                 }
                 if (req.has("getPackageHierarchy")) {

--- a/cli/src/test/java/tech/softwareologists/cli/StdioMcpServerTest.java
+++ b/cli/src/test/java/tech/softwareologists/cli/StdioMcpServerTest.java
@@ -18,68 +18,68 @@ public class StdioMcpServerTest {
 
         QueryService qs = new QueryService() {
             @Override
-            public java.util.List<String> findCallers(String className) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findCallers(String className, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findImplementations(String interfaceName) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findImplementations(String interfaceName, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findSubclasses(String className, int depth) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findSubclasses(String className, int depth, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findDependencies(String className, Integer depth) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findDependencies(String className, Integer depth, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findBeansWithAnnotation(String annotation) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findBeansWithAnnotation(String annotation, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> searchByAnnotation(String annotation, String targetType) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> searchByAnnotation(String annotation, String targetType, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findHttpEndpoints(String basePath, String httpMethod) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findHttpEndpoints(String basePath, String httpMethod, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findControllersUsingService(String serviceClassName) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findControllersUsingService(String serviceClassName, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findEventListeners(String eventType) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findEventListeners(String eventType, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findScheduledTasks() {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findScheduledTasks(Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findConfigPropertyUsage(String propertyKey) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findConfigPropertyUsage(String propertyKey, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
@@ -119,68 +119,68 @@ public class StdioMcpServerTest {
 
         QueryService qs = new QueryService() {
             @Override
-            public java.util.List<String> findCallers(String className) {
-                return java.util.Collections.singletonList("B");
+            public tech.softwareologists.core.QueryResult<String> findCallers(String className, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.singletonList("B"),1,1,1);
             }
 
             @Override
-            public java.util.List<String> findImplementations(String interfaceName) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findImplementations(String interfaceName, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findSubclasses(String className, int depth) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findSubclasses(String className, int depth, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findDependencies(String className, Integer depth) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findDependencies(String className, Integer depth, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findBeansWithAnnotation(String annotation) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findBeansWithAnnotation(String annotation, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> searchByAnnotation(String annotation, String targetType) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> searchByAnnotation(String annotation, String targetType, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findHttpEndpoints(String basePath, String httpMethod) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findHttpEndpoints(String basePath, String httpMethod, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findControllersUsingService(String serviceClassName) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findControllersUsingService(String serviceClassName, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findEventListeners(String eventType) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findEventListeners(String eventType, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findScheduledTasks() {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findScheduledTasks(Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findConfigPropertyUsage(String propertyKey) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findConfigPropertyUsage(String propertyKey, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override

--- a/core/src/main/java/tech/softwareologists/core/QueryService.java
+++ b/core/src/main/java/tech/softwareologists/core/QueryService.java
@@ -1,22 +1,58 @@
 package tech.softwareologists.core;
 
 import java.util.List;
+import tech.softwareologists.core.QueryResult;
+
+/**
+ * Service API for querying the code graph.
+ */
 
 public interface QueryService {
-    List<String> findCallers(String className);
+    /**
+     * Find classes that reference the given class.
+     *
+     * @param className fully qualified class name
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return callers of the class
+     */
+    QueryResult<String> findCallers(String className, Integer limit, Integer page, Integer pageSize);
 
-    List<String> findImplementations(String interfaceName);
+    /**
+     * Find classes implementing the specified interface.
+     *
+     * @param interfaceName fully qualified interface name
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return implementing class names
+     */
+    QueryResult<String> findImplementations(String interfaceName, Integer limit, Integer page, Integer pageSize);
 
-    List<String> findSubclasses(String className, int depth);
+    /**
+     * Find subclasses of a class up to the given depth.
+     *
+     * @param className fully qualified base class name
+     * @param depth search depth
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return subclass names
+     */
+    QueryResult<String> findSubclasses(String className, int depth, Integer limit, Integer page, Integer pageSize);
 
     /**
      * Find the classes that the given class depends on.
      *
      * @param className name of the source class
-     * @param depth maximum number of dependency classes to return, or {@code null} for no limit
-     * @return list of dependent class names
-    */
-    List<String> findDependencies(String className, Integer depth);
+     * @param depth maximum dependency search depth
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return dependent class names
+     */
+    QueryResult<String> findDependencies(String className, Integer depth, Integer limit, Integer page, Integer pageSize);
 
     /**
      * Find the shortest dependency path from one class to another.
@@ -26,74 +62,97 @@ public interface QueryService {
      * @param maxDepth maximum path length, or {@code null} for no limit
      * @return ordered list of class names from source to target, or empty if no path
      */
-    List<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth);
+    QueryResult<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth);
 
     /**
      * Find methods that invoke a given target method.
      *
      * @param className fully qualified class name containing the target method
      * @param methodSignature JVM signature of the target method
-     * @param limit maximum number of caller methods to return, or {@code null} for no limit
-     * @return list of caller method signatures
+     * @param limit optional maximum number of caller methods
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return caller method signatures
      */
-    List<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit);
+    QueryResult<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit, Integer page, Integer pageSize);
 
     /**
      * Find classes annotated with the given annotation.
      *
      * @param annotation fully qualified annotation name
-     * @return list of class names
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return class names
      */
-    List<String> findBeansWithAnnotation(String annotation);
+    QueryResult<String> findBeansWithAnnotation(String annotation, Integer limit, Integer page, Integer pageSize);
 
     /**
      * Generic search for nodes annotated with the given annotation.
      *
      * @param annotation fully qualified annotation name
      * @param targetType "class" or "method" to indicate target node label
-     * @return list of class names or method signatures
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return class names or method signatures
      */
-    List<String> searchByAnnotation(String annotation, String targetType);
+    QueryResult<String> searchByAnnotation(String annotation, String targetType, Integer limit, Integer page, Integer pageSize);
 
     /**
      * Find HTTP endpoint methods matching the given path prefix and verb.
      *
      * @param basePath base path to match against the stored route
      * @param httpMethod HTTP verb such as GET or POST
-     * @return list of "class|signature" pairs
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return "class|signature" pairs
      */
-    List<String> findHttpEndpoints(String basePath, String httpMethod);
+    QueryResult<String> findHttpEndpoints(String basePath, String httpMethod, Integer limit, Integer page, Integer pageSize);
 
     /**
      * Find controller classes that use the specified service class via injection.
      *
      * @param serviceClassName fully qualified service class name
-     * @return list of controller class names
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return controller class names
      */
-    List<String> findControllersUsingService(String serviceClassName);
+    QueryResult<String> findControllersUsingService(String serviceClassName, Integer limit, Integer page, Integer pageSize);
 
     /**
      * Find methods annotated with {@code @EventListener} for the given event type.
      *
      * @param eventType fully qualified event class name
-     * @return list of "class|signature" pairs
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return "class|signature" pairs
      */
-    List<String> findEventListeners(String eventType);
+    QueryResult<String> findEventListeners(String eventType, Integer limit, Integer page, Integer pageSize);
 
     /**
      * Find methods annotated with {@code @Scheduled}.
      *
-     * @return list of "class|signature|cron" entries
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return "class|signature|cron" entries
      */
-    List<String> findScheduledTasks();
+    QueryResult<String> findScheduledTasks(Integer limit, Integer page, Integer pageSize);
 
     /**
      * Find classes or methods that reference the given configuration property key.
      *
      * @param propertyKey configuration property key
-     * @return list of class names or "class|signature" for methods
+     * @param limit optional maximum number of results
+     * @param page result page number starting at 1
+     * @param pageSize number of items per page
+     * @return class names or "class|signature" for methods
      */
-    List<String> findConfigPropertyUsage(String propertyKey);
+    QueryResult<String> findConfigPropertyUsage(String propertyKey, Integer limit, Integer page, Integer pageSize);
 
     /**
      * Return a JSON tree of packages and classes starting from the given root package.

--- a/core/src/test/java/tech/softwareologists/core/CoreEngineTest.java
+++ b/core/src/test/java/tech/softwareologists/core/CoreEngineTest.java
@@ -40,9 +40,9 @@ public class CoreEngineTest {
 
         try (CoreEngine engine = new CoreEngineImpl()) {
             engine.importJar(jar);
-            java.util.List<String> callers = engine.getQueryService().findCallers("dep.A");
-            if (callers.size() != 1 || !callers.get(0).equals("dep.B")) {
-                throw new AssertionError("Unexpected callers: " + callers);
+            tech.softwareologists.core.QueryResult<String> callers = engine.getQueryService().findCallers("dep.A", null, null, null);
+            if (callers.getItems().size() != 1 || !callers.getItems().get(0).equals("dep.B")) {
+                throw new AssertionError("Unexpected callers: " + callers.getItems());
             }
 
             String manifest = engine.getManifest();

--- a/core/src/test/java/tech/softwareologists/core/QueryServiceImplTest.java
+++ b/core/src/test/java/tech/softwareologists/core/QueryServiceImplTest.java
@@ -20,9 +20,9 @@ public class QueryServiceImplTest {
             }
 
             QueryService service = new QueryServiceImpl(driver);
-            List<String> callers = service.findCallers("dep.A");
-            if (callers.size() != 1 || !callers.get(0).equals("dep.B")) {
-                throw new AssertionError("Unexpected callers: " + callers);
+            tech.softwareologists.core.QueryResult<String> callers = service.findCallers("dep.A", null, null, null);
+            if (callers.getItems().size() != 1 || !callers.getItems().get(0).equals("dep.B")) {
+                throw new AssertionError("Unexpected callers: " + callers.getItems());
             }
         }
     }
@@ -58,12 +58,12 @@ public class QueryServiceImplTest {
             JarImporter.importJar(jar, driver);
 
             QueryService service = new QueryServiceImpl(driver);
-            java.util.List<String> impls = service.findImplementations("impl.MyIntf");
+            tech.softwareologists.core.QueryResult<String> impls = service.findImplementations("impl.MyIntf", null, null, null);
             java.util.Set<String> expected = new java.util.HashSet<>();
             expected.add("impl.ImplA");
             expected.add("impl.ImplB");
-            if (!impls.containsAll(expected) || impls.size() != 2) {
-                throw new AssertionError("Unexpected implementations: " + impls);
+            if (!impls.getItems().containsAll(expected) || impls.getItems().size() != 2) {
+                throw new AssertionError("Unexpected implementations: " + impls.getItems());
             }
         }
     }
@@ -99,17 +99,17 @@ public class QueryServiceImplTest {
             JarImporter.importJar(jar, driver);
 
             QueryService service = new QueryServiceImpl(driver);
-            java.util.List<String> depth1 = service.findSubclasses("hier.Base", 1);
-            if (depth1.size() != 1 || !depth1.get(0).equals("hier.Mid")) {
-                throw new AssertionError("Unexpected depth1 result: " + depth1);
+            tech.softwareologists.core.QueryResult<String> depth1 = service.findSubclasses("hier.Base", 1, null, null, null);
+            if (depth1.getItems().size() != 1 || !depth1.getItems().get(0).equals("hier.Mid")) {
+                throw new AssertionError("Unexpected depth1 result: " + depth1.getItems());
             }
 
-            java.util.List<String> depth2 = service.findSubclasses("hier.Base", 2);
+            tech.softwareologists.core.QueryResult<String> depth2 = service.findSubclasses("hier.Base", 2, null, null, null);
             java.util.Set<String> expected = new java.util.HashSet<>();
             expected.add("hier.Mid");
             expected.add("hier.Leaf");
-            if (!depth2.containsAll(expected) || depth2.size() != 2) {
-                throw new AssertionError("Unexpected depth2 result: " + depth2);
+            if (!depth2.getItems().containsAll(expected) || depth2.getItems().size() != 2) {
+                throw new AssertionError("Unexpected depth2 result: " + depth2.getItems());
             }
         }
     }
@@ -127,17 +127,17 @@ public class QueryServiceImplTest {
             }
 
             QueryService service = new QueryServiceImpl(driver);
-            List<String> depth1 = service.findDependencies("A", 1);
-            if (depth1.size() != 1 || !depth1.get(0).equals("B")) {
-                throw new AssertionError("Unexpected depth1 result: " + depth1);
+            tech.softwareologists.core.QueryResult<String> depth1 = service.findDependencies("A", 1, null, null, null);
+            if (depth1.getItems().size() != 1 || !depth1.getItems().get(0).equals("B")) {
+                throw new AssertionError("Unexpected depth1 result: " + depth1.getItems());
             }
 
-            List<String> depth2 = service.findDependencies("A", 2);
+            tech.softwareologists.core.QueryResult<String> depth2 = service.findDependencies("A", 2, null, null, null);
             java.util.Set<String> expected = new java.util.HashSet<>();
             expected.add("B");
             expected.add("C");
-            if (!depth2.containsAll(expected) || depth2.size() != 2) {
-                throw new AssertionError("Unexpected depth2 result: " + depth2);
+            if (!depth2.getItems().containsAll(expected) || depth2.getItems().size() != 2) {
+                throw new AssertionError("Unexpected depth2 result: " + depth2.getItems());
             }
         }
     }
@@ -157,15 +157,15 @@ public class QueryServiceImplTest {
             }
 
             QueryService service = new QueryServiceImpl(driver);
-            java.util.List<String> within = service.findPathBetweenClasses("A", "D", 3);
+            tech.softwareologists.core.QueryResult<String> within = service.findPathBetweenClasses("A", "D", 3);
             java.util.List<String> expected = java.util.Arrays.asList("A", "B", "C", "D");
-            if (!within.equals(expected)) {
-                throw new AssertionError("Unexpected path: " + within);
+            if (!within.getItems().equals(expected)) {
+                throw new AssertionError("Unexpected path: " + within.getItems());
             }
 
-            java.util.List<String> tooShort = service.findPathBetweenClasses("A", "D", 2);
-            if (!tooShort.isEmpty()) {
-                throw new AssertionError("Path should be empty when exceeding depth: " + tooShort);
+            tech.softwareologists.core.QueryResult<String> tooShort = service.findPathBetweenClasses("A", "D", 2);
+            if (!tooShort.getItems().isEmpty()) {
+                throw new AssertionError("Path should be empty when exceeding depth: " + tooShort.getItems());
             }
         }
     }
@@ -181,9 +181,9 @@ public class QueryServiceImplTest {
             }
 
             QueryService service = new QueryServiceImpl(driver);
-            List<String> callers = service.findMethodsCallingMethod("A", "a()V", null);
-            if (callers.size() != 1 || !callers.get(0).equals("b()V")) {
-                throw new AssertionError("Unexpected callers: " + callers);
+            tech.softwareologists.core.QueryResult<String> callers = service.findMethodsCallingMethod("A", "a()V", null, null, null);
+            if (callers.getItems().size() != 1 || !callers.getItems().get(0).equals("b()V")) {
+                throw new AssertionError("Unexpected callers: " + callers.getItems());
             }
         }
     }
@@ -201,16 +201,16 @@ public class QueryServiceImplTest {
             }
 
             QueryService service = new QueryServiceImpl(driver);
-            List<String> limit1 = service.findMethodsCallingMethod("A", "a()V", 1);
-            if (limit1.size() != 1) {
-                throw new AssertionError("Unexpected limit1 result: " + limit1);
+            tech.softwareologists.core.QueryResult<String> limit1 = service.findMethodsCallingMethod("A", "a()V", 1, null, null);
+            if (limit1.getItems().size() != 1) {
+                throw new AssertionError("Unexpected limit1 result: " + limit1.getItems());
             }
-            List<String> all = service.findMethodsCallingMethod("A", "a()V", null);
+            tech.softwareologists.core.QueryResult<String> all = service.findMethodsCallingMethod("A", "a()V", null, null, null);
             java.util.Set<String> expected = new java.util.HashSet<>();
             expected.add("b()V");
             expected.add("c()V");
-            if (!all.containsAll(expected) || all.size() != 2) {
-                throw new AssertionError("Unexpected all result: " + all);
+            if (!all.getItems().containsAll(expected) || all.getItems().size() != 2) {
+                throw new AssertionError("Unexpected all result: " + all.getItems());
             }
         }
     }
@@ -246,17 +246,17 @@ public class QueryServiceImplTest {
             JarImporter.importJar(jar, driver);
 
             QueryService service = new QueryServiceImpl(driver);
-            java.util.List<String> all = service.findMethodsCallingMethod("invoke.Callee", "methodB()V", null);
+            tech.softwareologists.core.QueryResult<String> all = service.findMethodsCallingMethod("invoke.Callee", "methodB()V", null, null, null);
             java.util.Set<String> expected = new java.util.HashSet<>();
             expected.add("methodA()V");
             expected.add("methodC()V");
-            if (!all.containsAll(expected) || all.size() != 2) {
-                throw new AssertionError("Unexpected all result: " + all);
+            if (!all.getItems().containsAll(expected) || all.getItems().size() != 2) {
+                throw new AssertionError("Unexpected all result: " + all.getItems());
             }
 
-            java.util.List<String> limit1 = service.findMethodsCallingMethod("invoke.Callee", "methodB()V", 1);
-            if (limit1.size() != 1 || !expected.contains(limit1.get(0))) {
-                throw new AssertionError("Unexpected limit result: " + limit1);
+            tech.softwareologists.core.QueryResult<String> limit1 = service.findMethodsCallingMethod("invoke.Callee", "methodB()V", 1, null, null);
+            if (limit1.getItems().size() != 1 || !expected.contains(limit1.getItems().get(0))) {
+                throw new AssertionError("Unexpected limit result: " + limit1.getItems());
             }
         }
     }
@@ -295,14 +295,14 @@ public class QueryServiceImplTest {
             JarImporter.importJar(jar, driver);
 
             QueryService service = new QueryServiceImpl(driver);
-            java.util.List<String> classes = service.findBeansWithAnnotation("ann.MyAnno");
-            if (classes.size() != 1 || !classes.get(0).equals("ann.AnnoClass")) {
-                throw new AssertionError("Unexpected classes: " + classes);
+            tech.softwareologists.core.QueryResult<String> classes = service.findBeansWithAnnotation("ann.MyAnno", null, null, null);
+            if (classes.getItems().size() != 1 || !classes.getItems().get(0).equals("ann.AnnoClass")) {
+                throw new AssertionError("Unexpected classes: " + classes.getItems());
             }
 
-            java.util.List<String> methods = service.searchByAnnotation("ann.MyAnno", "method");
-            if (methods.size() != 1 || !methods.get(0).equals("foo()V")) {
-                throw new AssertionError("Unexpected methods: " + methods);
+            tech.softwareologists.core.QueryResult<String> methods = service.searchByAnnotation("ann.MyAnno", "method", null, null, null);
+            if (methods.getItems().size() != 1 || !methods.getItems().get(0).equals("foo()V")) {
+                throw new AssertionError("Unexpected methods: " + methods.getItems());
             }
         }
     }
@@ -363,14 +363,14 @@ public class QueryServiceImplTest {
             JarImporter.importJar(jar, driver);
 
             QueryService service = new QueryServiceImpl(driver);
-            java.util.List<String> get = service.findHttpEndpoints("/foo", "GET");
-            if (get.size() != 1 || !get.get(0).contains("foo()V")) {
-                throw new AssertionError("Unexpected GET result: " + get);
+            tech.softwareologists.core.QueryResult<String> get = service.findHttpEndpoints("/foo", "GET", null, null, null);
+            if (get.getItems().size() != 1 || !get.getItems().get(0).contains("foo()V")) {
+                throw new AssertionError("Unexpected GET result: " + get.getItems());
             }
 
-            java.util.List<String> post = service.findHttpEndpoints("/bar", "POST");
-            if (post.size() != 1 || !post.get(0).contains("bar()V")) {
-                throw new AssertionError("Unexpected POST result: " + post);
+            tech.softwareologists.core.QueryResult<String> post = service.findHttpEndpoints("/bar", "POST", null, null, null);
+            if (post.getItems().size() != 1 || !post.getItems().get(0).contains("bar()V")) {
+                throw new AssertionError("Unexpected POST result: " + post.getItems());
             }
         }
     }
@@ -426,9 +426,9 @@ public class QueryServiceImplTest {
             JarImporter.importJar(jar, driver);
 
             QueryService serviceApi = new QueryServiceImpl(driver);
-            java.util.List<String> ctrls = serviceApi.findControllersUsingService("inj.MyService");
-            if (ctrls.size() != 1 || !ctrls.get(0).equals("inj.MyController")) {
-                throw new AssertionError("Unexpected controllers: " + ctrls);
+            tech.softwareologists.core.QueryResult<String> ctrls = serviceApi.findControllersUsingService("inj.MyService", null, null, null);
+            if (ctrls.getItems().size() != 1 || !ctrls.getItems().get(0).equals("inj.MyController")) {
+                throw new AssertionError("Unexpected controllers: " + ctrls.getItems());
             }
         }
     }
@@ -478,9 +478,9 @@ public class QueryServiceImplTest {
             JarImporter.importJar(jar, driver);
 
             QueryService svc = new QueryServiceImpl(driver);
-            java.util.List<String> listeners = svc.findEventListeners("evt.MyEvent");
-            if (listeners.size() != 1 || !listeners.get(0).contains("handle")) {
-                throw new AssertionError("Unexpected listeners: " + listeners);
+            tech.softwareologists.core.QueryResult<String> listeners = svc.findEventListeners("evt.MyEvent", null, null, null);
+            if (listeners.getItems().size() != 1 || !listeners.getItems().get(0).contains("handle")) {
+                throw new AssertionError("Unexpected listeners: " + listeners.getItems());
             }
         }
     }
@@ -527,9 +527,9 @@ public class QueryServiceImplTest {
             JarImporter.importJar(jar, driver);
 
             QueryService svc = new QueryServiceImpl(driver);
-            java.util.List<String> tasks = svc.findScheduledTasks();
-            if (tasks.size() != 1 || !tasks.get(0).contains("run()V|0 0 * * * *")) {
-                throw new AssertionError("Unexpected tasks: " + tasks);
+            tech.softwareologists.core.QueryResult<String> tasks = svc.findScheduledTasks(null, null, null);
+            if (tasks.getItems().size() != 1 || !tasks.getItems().get(0).contains("run()V|0 0 * * * *")) {
+                throw new AssertionError("Unexpected tasks: " + tasks.getItems());
             }
         }
     }
@@ -591,13 +591,13 @@ public class QueryServiceImplTest {
             JarImporter.importJar(jar, driver);
 
             QueryService svc = new QueryServiceImpl(driver);
-            java.util.List<String> clsRes = svc.findConfigPropertyUsage("app.url");
-            if (clsRes.size() != 1 || !clsRes.get(0).equals("cfg.MyClass")) {
-                throw new AssertionError("Unexpected class usage: " + clsRes);
+            tech.softwareologists.core.QueryResult<String> clsRes = svc.findConfigPropertyUsage("app.url", null, null, null);
+            if (clsRes.getItems().size() != 1 || !clsRes.getItems().get(0).equals("cfg.MyClass")) {
+                throw new AssertionError("Unexpected class usage: " + clsRes.getItems());
             }
-            java.util.List<String> methRes = svc.findConfigPropertyUsage("app.timeout");
-            if (methRes.size() != 1 || !methRes.get(0).equals("cfg.MyClass|set(I)V")) {
-                throw new AssertionError("Unexpected method usage: " + methRes);
+            tech.softwareologists.core.QueryResult<String> methRes = svc.findConfigPropertyUsage("app.timeout", null, null, null);
+            if (methRes.getItems().size() != 1 || !methRes.getItems().get(0).equals("cfg.MyClass|set(I)V")) {
+                throw new AssertionError("Unexpected method usage: " + methRes.getItems());
             }
         }
     }

--- a/intellij/src/main/java/tech/softwareologists/ij/server/HttpMcpServer.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/server/HttpMcpServer.java
@@ -73,10 +73,10 @@ public class HttpMcpServer {
 
                 if (req.has("findCallers")) {
                     String cls = req.getString("findCallers");
-                    response = new JSONArray(queryService.findCallers(cls)).toString();
+                    response = new JSONArray(queryService.findCallers(cls, null, null, null).getItems()).toString();
                 } else if (req.has("findImplementations")) {
                     String iface = req.getString("findImplementations");
-                    response = new JSONArray(queryService.findImplementations(iface)).toString();
+                    response = new JSONArray(queryService.findImplementations(iface, null, null, null).getItems()).toString();
                 } else if (req.has("findSubclasses")) {
                     Object val = req.get("findSubclasses");
                     String cls;
@@ -88,7 +88,7 @@ public class HttpMcpServer {
                     } else {
                         cls = val.toString();
                     }
-                    response = new JSONArray(queryService.findSubclasses(cls, depth)).toString();
+                    response = new JSONArray(queryService.findSubclasses(cls, depth, null, null, null).getItems()).toString();
                 } else if (req.has("findDependencies")) {
                     Object val = req.get("findDependencies");
                     String cls;
@@ -100,43 +100,43 @@ public class HttpMcpServer {
                     } else {
                         cls = val.toString();
                     }
-                    response = new JSONArray(queryService.findDependencies(cls, depth)).toString();
+                    response = new JSONArray(queryService.findDependencies(cls, depth, null, null, null).getItems()).toString();
                 } else if (req.has("findPathBetweenClasses")) {
                     JSONObject o = req.getJSONObject("findPathBetweenClasses");
                     String from = o.getString("fromClass");
                     String to = o.getString("toClass");
                     Integer max = o.has("maxDepth") ? o.getInt("maxDepth") : null;
-                    response = new JSONArray(queryService.findPathBetweenClasses(from, to, max)).toString();
+                    response = new JSONArray(queryService.findPathBetweenClasses(from, to, max).getItems()).toString();
                 } else if (req.has("findMethodsCallingMethod")) {
                     JSONObject o = req.getJSONObject("findMethodsCallingMethod");
                     String cls = o.getString("className");
                     String sig = o.getString("methodSignature");
                     Integer lim = o.has("limit") ? o.getInt("limit") : null;
-                    response = new JSONArray(queryService.findMethodsCallingMethod(cls, sig, lim)).toString();
+                    response = new JSONArray(queryService.findMethodsCallingMethod(cls, sig, lim, null, null).getItems()).toString();
                 } else if (req.has("findBeansWithAnnotation")) {
                     String ann = req.getString("findBeansWithAnnotation");
-                    response = new JSONArray(queryService.findBeansWithAnnotation(ann)).toString();
+                    response = new JSONArray(queryService.findBeansWithAnnotation(ann, null, null, null).getItems()).toString();
                 } else if (req.has("searchByAnnotation")) {
                     JSONObject o = req.getJSONObject("searchByAnnotation");
                     String ann = o.getString("annotation");
                     String target = o.optString("targetType", "class");
-                    response = new JSONArray(queryService.searchByAnnotation(ann, target)).toString();
+                    response = new JSONArray(queryService.searchByAnnotation(ann, target, null, null, null).getItems()).toString();
                 } else if (req.has("findHttpEndpoints")) {
                     JSONObject o = req.getJSONObject("findHttpEndpoints");
                     String base = o.getString("basePath");
                     String verb = o.getString("httpMethod");
-                    response = new JSONArray(queryService.findHttpEndpoints(base, verb)).toString();
+                    response = new JSONArray(queryService.findHttpEndpoints(base, verb, null, null, null).getItems()).toString();
                 } else if (req.has("findControllersUsingService")) {
                     String svc = req.getString("findControllersUsingService");
-                    response = new JSONArray(queryService.findControllersUsingService(svc)).toString();
+                    response = new JSONArray(queryService.findControllersUsingService(svc, null, null, null).getItems()).toString();
                 } else if (req.has("findEventListeners")) {
                     String ev = req.getString("findEventListeners");
-                    response = new JSONArray(queryService.findEventListeners(ev)).toString();
+                    response = new JSONArray(queryService.findEventListeners(ev, null, null, null).getItems()).toString();
                 } else if (req.has("findScheduledTasks")) {
-                    response = new JSONArray(queryService.findScheduledTasks()).toString();
+                    response = new JSONArray(queryService.findScheduledTasks(null, null, null).getItems()).toString();
                 } else if (req.has("findConfigPropertyUsage")) {
                     String key = req.getString("findConfigPropertyUsage");
-                    response = new JSONArray(queryService.findConfigPropertyUsage(key)).toString();
+                    response = new JSONArray(queryService.findConfigPropertyUsage(key, null, null, null).getItems()).toString();
                 } else if (req.has("getPackageHierarchy")) {
                     Object val = req.get("getPackageHierarchy");
                     String pkg;

--- a/intellij/src/test/java/tech/softwareologists/ij/HttpMcpServerTest.java
+++ b/intellij/src/test/java/tech/softwareologists/ij/HttpMcpServerTest.java
@@ -17,68 +17,68 @@ public class HttpMcpServerTest {
     public void manifestAndQuery_returnJson() throws Exception {
         QueryService qs = new QueryService() {
             @Override
-            public java.util.List<String> findCallers(String className) {
-                return java.util.Collections.singletonList("Caller");
+            public tech.softwareologists.core.QueryResult<String> findCallers(String className, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.singletonList("Caller"),1,1,1);
             }
 
             @Override
-            public java.util.List<String> findImplementations(String interfaceName) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findImplementations(String interfaceName, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findSubclasses(String className, int depth) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findSubclasses(String className, int depth, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findDependencies(String className, Integer depth) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findDependencies(String className, Integer depth, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findBeansWithAnnotation(String annotation) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findBeansWithAnnotation(String annotation, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> searchByAnnotation(String annotation, String targetType) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> searchByAnnotation(String annotation, String targetType, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findHttpEndpoints(String basePath, String httpMethod) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findHttpEndpoints(String basePath, String httpMethod, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findControllersUsingService(String serviceClassName) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findControllersUsingService(String serviceClassName, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findEventListeners(String eventType) {
-                return Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findEventListeners(String eventType, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findScheduledTasks() {
-                return Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findScheduledTasks(Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override
-            public java.util.List<String> findConfigPropertyUsage(String propertyKey) {
-                return java.util.Collections.emptyList();
+            public tech.softwareologists.core.QueryResult<String> findConfigPropertyUsage(String propertyKey, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(java.util.Collections.emptyList(),1,0,0);
             }
 
             @Override


### PR DESCRIPTION
## Summary
- return `QueryResult` from QueryService methods
- support optional paging parameters
- adapt implementation and servers
- update tests for new return type

## Testing
- `gradle :core:test :cli:test :intellij:test`

------
https://chatgpt.com/codex/tasks/task_b_6872ef1345dc832aa3f2e4c686c89981