### PR TITLE
FEAT-INTELLIJ-001: forward paging params

### DIFF
--- a/intellij/src/main/java/tech/softwareologists/ij/server/HttpMcpServer.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/server/HttpMcpServer.java
@@ -72,35 +72,73 @@ public class HttpMcpServer {
                 JSONObject req = new JSONObject(body);
 
                 if (req.has("findCallers")) {
-                    String cls = req.getString("findCallers");
-                    response = new JSONArray(queryService.findCallers(cls, null, null, null).getItems()).toString();
+                    Object val = req.get("findCallers");
+                    String cls;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        cls = o.getString("className");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        cls = val.toString();
+                    }
+                    response = new JSONArray(queryService.findCallers(cls, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("findImplementations")) {
-                    String iface = req.getString("findImplementations");
-                    response = new JSONArray(queryService.findImplementations(iface, null, null, null).getItems()).toString();
+                    Object val = req.get("findImplementations");
+                    String iface;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        iface = o.getString("interfaceName");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        iface = val.toString();
+                    }
+                    response = new JSONArray(queryService.findImplementations(iface, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("findSubclasses")) {
                     Object val = req.get("findSubclasses");
                     String cls;
                     int depth = 1;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
                     if (val instanceof JSONObject) {
                         JSONObject o = (JSONObject) val;
                         cls = o.getString("className");
                         depth = o.optInt("depth", 1);
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
                     } else {
                         cls = val.toString();
                     }
-                    response = new JSONArray(queryService.findSubclasses(cls, depth, null, null, null).getItems()).toString();
+                    response = new JSONArray(queryService.findSubclasses(cls, depth, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("findDependencies")) {
                     Object val = req.get("findDependencies");
                     String cls;
                     Integer depth = null;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
                     if (val instanceof JSONObject) {
                         JSONObject o = (JSONObject) val;
                         cls = o.getString("className");
                         depth = o.has("depth") ? o.getInt("depth") : null;
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
                     } else {
                         cls = val.toString();
                     }
-                    response = new JSONArray(queryService.findDependencies(cls, depth, null, null, null).getItems()).toString();
+                    response = new JSONArray(queryService.findDependencies(cls, depth, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("findPathBetweenClasses")) {
                     JSONObject o = req.getJSONObject("findPathBetweenClasses");
                     String from = o.getString("fromClass");
@@ -112,31 +150,100 @@ public class HttpMcpServer {
                     String cls = o.getString("className");
                     String sig = o.getString("methodSignature");
                     Integer lim = o.has("limit") ? o.getInt("limit") : null;
-                    response = new JSONArray(queryService.findMethodsCallingMethod(cls, sig, lim, null, null).getItems()).toString();
+                    Integer page = o.has("page") ? o.getInt("page") : null;
+                    Integer pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    response = new JSONArray(queryService.findMethodsCallingMethod(cls, sig, lim, page, pageSize).getItems()).toString();
                 } else if (req.has("findBeansWithAnnotation")) {
-                    String ann = req.getString("findBeansWithAnnotation");
-                    response = new JSONArray(queryService.findBeansWithAnnotation(ann, null, null, null).getItems()).toString();
+                    Object val = req.get("findBeansWithAnnotation");
+                    String ann;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        ann = o.getString("annotation");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        ann = val.toString();
+                    }
+                    response = new JSONArray(queryService.findBeansWithAnnotation(ann, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("searchByAnnotation")) {
                     JSONObject o = req.getJSONObject("searchByAnnotation");
                     String ann = o.getString("annotation");
                     String target = o.optString("targetType", "class");
-                    response = new JSONArray(queryService.searchByAnnotation(ann, target, null, null, null).getItems()).toString();
+                    Integer limit = o.has("limit") ? o.getInt("limit") : null;
+                    Integer page = o.has("page") ? o.getInt("page") : null;
+                    Integer pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    response = new JSONArray(queryService.searchByAnnotation(ann, target, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("findHttpEndpoints")) {
                     JSONObject o = req.getJSONObject("findHttpEndpoints");
                     String base = o.getString("basePath");
                     String verb = o.getString("httpMethod");
-                    response = new JSONArray(queryService.findHttpEndpoints(base, verb, null, null, null).getItems()).toString();
+                    Integer limit = o.has("limit") ? o.getInt("limit") : null;
+                    Integer page = o.has("page") ? o.getInt("page") : null;
+                    Integer pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    response = new JSONArray(queryService.findHttpEndpoints(base, verb, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("findControllersUsingService")) {
-                    String svc = req.getString("findControllersUsingService");
-                    response = new JSONArray(queryService.findControllersUsingService(svc, null, null, null).getItems()).toString();
+                    Object val = req.get("findControllersUsingService");
+                    String svc;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        svc = o.getString("serviceClassName");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        svc = val.toString();
+                    }
+                    response = new JSONArray(queryService.findControllersUsingService(svc, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("findEventListeners")) {
-                    String ev = req.getString("findEventListeners");
-                    response = new JSONArray(queryService.findEventListeners(ev, null, null, null).getItems()).toString();
+                    Object val = req.get("findEventListeners");
+                    String ev;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        ev = o.getString("eventType");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        ev = val.toString();
+                    }
+                    response = new JSONArray(queryService.findEventListeners(ev, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("findScheduledTasks")) {
-                    response = new JSONArray(queryService.findScheduledTasks(null, null, null).getItems()).toString();
+                    JSONObject o = req.optJSONObject("findScheduledTasks");
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (o != null) {
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    }
+                    response = new JSONArray(queryService.findScheduledTasks(limit, page, pageSize).getItems()).toString();
                 } else if (req.has("findConfigPropertyUsage")) {
-                    String key = req.getString("findConfigPropertyUsage");
-                    response = new JSONArray(queryService.findConfigPropertyUsage(key, null, null, null).getItems()).toString();
+                    Object val = req.get("findConfigPropertyUsage");
+                    String key;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        key = o.getString("propertyKey");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        key = val.toString();
+                    }
+                    response = new JSONArray(queryService.findConfigPropertyUsage(key, limit, page, pageSize).getItems()).toString();
                 } else if (req.has("getPackageHierarchy")) {
                     Object val = req.get("getPackageHierarchy");
                     String pkg;

--- a/intellij/src/test/java/tech/softwareologists/ij/HttpMcpServerTest.java
+++ b/intellij/src/test/java/tech/softwareologists/ij/HttpMcpServerTest.java
@@ -131,4 +131,150 @@ public class HttpMcpServerTest {
         }
         server.stop();
     }
+
+    @Test
+    public void findCallersRequest_pagingParametersPassed() throws Exception {
+        QueryService qs = new QueryService() {
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findCallers(String className, Integer limit, Integer page, Integer pageSize) {
+                if (!"A".equals(className) || limit == null || limit != 10 || page == null || page != 2 || pageSize == null || pageSize != 5) {
+                    throw new AssertionError("Paging parameters not forwarded");
+                }
+                return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0);
+            }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findImplementations(String interfaceName, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findSubclasses(String className, int depth, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findDependencies(String className, Integer depth, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findBeansWithAnnotation(String annotation, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> searchByAnnotation(String annotation, String targetType, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findHttpEndpoints(String basePath, String httpMethod, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findControllersUsingService(String serviceClassName, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findEventListeners(String eventType, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findScheduledTasks(Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findConfigPropertyUsage(String propertyKey, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public String getPackageHierarchy(String rootPackage, Integer depth) { return "{}"; }
+
+            @Override
+            public String getGraphStatistics(Integer topN) { return "{}"; }
+
+            @Override
+            public void exportGraph(String format, String outputPath) {}
+        };
+
+        HttpMcpServer server = new HttpMcpServer(0, qs);
+        server.start();
+        int port = server.getPort();
+
+        HttpClient client = HttpClient.newHttpClient();
+        String body = "{\"findCallers\":{\"className\":\"A\",\"limit\":10,\"page\":2,\"pageSize\":5}}";
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:" + port + "/mcp/query"))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .header("Content-Type", "application/json")
+                .build();
+
+        client.send(req, HttpResponse.BodyHandlers.ofString());
+        server.stop();
+    }
+
+    @Test
+    public void findSubclassesRequest_pagingParametersPassed() throws Exception {
+        QueryService qs = new QueryService() {
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findCallers(String className, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findImplementations(String interfaceName, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findSubclasses(String className, int depth, Integer limit, Integer page, Integer pageSize) {
+                if (!"B".equals(className) || depth != 2 || limit == null || limit != 7 || page == null || page != 3 || pageSize == null || pageSize != 4) {
+                    throw new AssertionError("Paging parameters not forwarded");
+                }
+                return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0);
+            }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findDependencies(String className, Integer depth, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findBeansWithAnnotation(String annotation, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> searchByAnnotation(String annotation, String targetType, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findHttpEndpoints(String basePath, String httpMethod, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findControllersUsingService(String serviceClassName, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findEventListeners(String eventType, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findScheduledTasks(Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findConfigPropertyUsage(String propertyKey, Integer limit, Integer page, Integer pageSize) { return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+
+            @Override
+            public String getPackageHierarchy(String rootPackage, Integer depth) { return "{}"; }
+
+            @Override
+            public String getGraphStatistics(Integer topN) { return "{}"; }
+
+            @Override
+            public void exportGraph(String format, String outputPath) {}
+        };
+
+        HttpMcpServer server = new HttpMcpServer(0, qs);
+        server.start();
+        int port = server.getPort();
+
+        HttpClient client = HttpClient.newHttpClient();
+        String body = "{\"findSubclasses\":{\"className\":\"B\",\"depth\":2,\"limit\":7,\"page\":3,\"pageSize\":4}}";
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:" + port + "/mcp/query"))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .header("Content-Type", "application/json")
+                .build();
+
+        client.send(req, HttpResponse.BodyHandlers.ofString());
+        server.stop();
+    }
 }


### PR DESCRIPTION
## Summary
- read limit, page and pageSize from HTTP query requests
- forward paging parameters to QueryService
- test paging parameter handling in HTTP server

## Testing
- `gradle spotlessApply`
- `gradle :intellij:test`

------
https://chatgpt.com/codex/tasks/task_b_68744481551c832ab631ea12ac30ad4f