### PR TITLE
FEAT-CLI-009: remove redundant WatchAdapter

### DIFF
--- a/cli/src/main/java/tech/softwareologists/cli/WatchAdapter.java
+++ b/cli/src/main/java/tech/softwareologists/cli/WatchAdapter.java
@@ -1,5 +1,0 @@
-package tech.softwareologists.cli;
-
-public class WatchAdapter {
-    // TODO: implement folder watching
-}


### PR DESCRIPTION
## Summary
- remove unused `WatchAdapter` class
- run CLI tests

## Testing
- `gradle :cli:test`

------
https://chatgpt.com/codex/tasks/task_b_68744ba9c104832abfe7b9800051ba88