### PR TITLE
FEAT-CLI-005: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  release:
+    types: [published, created]
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Generate Gradle Wrapper
+        run: gradle wrapper --gradle-version 8.5 --distribution-type all --console=plain
+      - name: Build Artifacts
+        run: ./gradlew :cli:shadowJar :intellij:buildPlugin --no-daemon --console=plain
+      - name: Detect Tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "tag_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag_name=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Pre-release Check
+        id: pre
+        run: |
+          TAG="${{ steps.tag.outputs.tag_name }}"
+          if [[ "$TAG" == *-* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Generate Changelog
+        id: changelog
+        run: |
+          TAG="${{ steps.tag.outputs.tag_name }}"
+          PREV_TAG=$(git describe --abbrev=0 --tags "$TAG^" 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            git log "$PREV_TAG..$TAG" --pretty=format:'* %s' > changelog.txt
+          else
+            git log "$TAG" --pretty=format:'* %s' > changelog.txt
+          fi
+          echo "changelog<<EOF" >> "$GITHUB_OUTPUT"
+          cat changelog.txt >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+      - name: Publish Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.tag.outputs.tag_name }}
+          name: ${{ steps.tag.outputs.tag_name }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          prerelease: ${{ steps.pre.outputs.is_prerelease }}
+          files: |
+            cli/build/libs/cli-all.jar
+            intellij/build/distributions/*.zip
+          draft: false
+          allow_updates: true


### PR DESCRIPTION
## Summary
- trigger release workflow on tag push or release event
- build CLI jar and IntelliJ plugin
- generate simple changelog and mark prerelease if tag has suffix
- upload jar and plugin zip as release assets

## Testing
- `gradle wrapper --gradle-version 8.5`
- `./gradlew build` *(failed: network unreachable during plugin build)*

------
https://chatgpt.com/codex/tasks/task_b_68745d2751c0832abea754070f6ccdae