### PR TITLE
FEAT-DOC-003: fix release changelog delimiter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,10 @@ jobs:
           else
             git log "$TAG" --pretty=format:'* %s' > changelog.txt
           fi
-          echo "changelog<<EOF" >> "$GITHUB_OUTPUT"
+          END_MARKER="$(uuidgen)"
+          echo "changelog<<$END_MARKER" >> "$GITHUB_OUTPUT"
           cat changelog.txt >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "$END_MARKER" >> "$GITHUB_OUTPUT"
       - name: Publish Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
## Summary
- adjust GitHub Actions release workflow to use a unique delimiter for the changelog output

## Testing
- `gradle build` *(fails: could not complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_b_687467f0ce00832a8174ec1851fb17c3