### PR TITLE
FEAT-CLI-001: Add SSE server

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ java-codegraph-mcp-server/
    ```bash
    java -jar cli/build/libs/cli-all.jar --watch-dir /path/to/jars --stdio
    ```
+   or start the SSE server:
+
+   ```bash
+   java -jar cli/build/libs/cli-all.jar --watch-dir /path/to/jars --sse-port 8080
+   ```
 4. **Send MCP Requests**
 
    * At startup, the manifest JSON is printed.
@@ -74,14 +79,22 @@ java-codegraph-mcp-server/
 
      ```bash
      echo '{"findCallers":{"className":"com.example.A","limit":10,"page":2,"pageSize":5}}' \
-       | java -jar cli/build/libs/cli-all.jar --watch-dir /path/to/jars --stdio
-     ```
-   * Omitted values fallback to the defaults printed in the manifest.
+      | java -jar cli/build/libs/cli-all.jar --watch-dir /path/to/jars --stdio
+    ```
+  * Omitted values fallback to the defaults printed in the manifest.
+  * When using the SSE server:
+
+    ```bash
+    curl -X POST -H "Content-Type: application/json" \
+      -d '{"findCallers":"com.example.A"}' \
+      http://localhost:8080/mcp/query
+    ```
 
 For a full demonstration:
 
 1. Run `examples/build-example-jar.sh` to create `examples/example.jar`.
 2. Execute `examples/sample-cli.sh` which builds the CLI, imports that JAR, and runs a sample query.
+3. For SSE usage run `examples/sample-sse.sh`.
 
 ## IntelliJ Plugin
 

--- a/cli/src/main/java/tech/softwareologists/cli/SseMcpServer.java
+++ b/cli/src/main/java/tech/softwareologists/cli/SseMcpServer.java
@@ -1,0 +1,283 @@
+package tech.softwareologists.cli;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import tech.softwareologists.core.ManifestGenerator;
+import tech.softwareologists.core.QueryService;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Minimal HTTP SSE server exposing MCP endpoints.
+ */
+public class SseMcpServer {
+    private final HttpServer server;
+    private final QueryService queryService;
+
+    public SseMcpServer(int port, QueryService queryService) throws IOException {
+        this.queryService = queryService;
+        this.server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/mcp/manifest", new ManifestHandler());
+        server.createContext("/mcp/query", new QueryHandler());
+    }
+
+    /** Starts the server. */
+    public void start() {
+        server.start();
+    }
+
+    /** Stops the server. */
+    public void stop() {
+        server.stop(0);
+    }
+
+    /** Returns the bound port. */
+    public int getPort() {
+        return server.getAddress().getPort();
+    }
+
+    private static byte[] formatEvent(String data) {
+        String event = "data: " + data.replace("\n", "") + "\n\n";
+        return event.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private class ManifestHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            byte[] bytes = formatEvent(ManifestGenerator.generate());
+            exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        }
+    }
+
+    private class QueryHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8).trim();
+            String response = "[]";
+            if (!body.isEmpty()) {
+                JSONObject req = new JSONObject(body);
+
+                if (req.has("findCallers")) {
+                    Object val = req.get("findCallers");
+                    String cls;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        cls = o.getString("className");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        cls = val.toString();
+                    }
+                    response = new JSONArray(queryService.findCallers(cls, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("findImplementations")) {
+                    Object val = req.get("findImplementations");
+                    String iface;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        iface = o.getString("interfaceName");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        iface = val.toString();
+                    }
+                    response = new JSONArray(queryService.findImplementations(iface, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("findSubclasses")) {
+                    Object val = req.get("findSubclasses");
+                    String cls;
+                    int depth = 1;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        cls = o.getString("className");
+                        depth = o.optInt("depth", 1);
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        cls = val.toString();
+                    }
+                    response = new JSONArray(queryService.findSubclasses(cls, depth, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("findDependencies")) {
+                    Object val = req.get("findDependencies");
+                    String cls;
+                    Integer depth = null;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        cls = o.getString("className");
+                        depth = o.has("depth") ? o.getInt("depth") : null;
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        cls = val.toString();
+                    }
+                    response = new JSONArray(queryService.findDependencies(cls, depth, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("findPathBetweenClasses")) {
+                    JSONObject o = req.getJSONObject("findPathBetweenClasses");
+                    String from = o.getString("fromClass");
+                    String to = o.getString("toClass");
+                    Integer max = o.has("maxDepth") ? o.getInt("maxDepth") : null;
+                    response = new JSONArray(queryService.findPathBetweenClasses(from, to, max).getItems()).toString();
+                } else if (req.has("findMethodsCallingMethod")) {
+                    JSONObject o = req.getJSONObject("findMethodsCallingMethod");
+                    String cls = o.getString("className");
+                    String sig = o.getString("methodSignature");
+                    Integer lim = o.has("limit") ? o.getInt("limit") : null;
+                    Integer page = o.has("page") ? o.getInt("page") : null;
+                    Integer pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    response = new JSONArray(queryService.findMethodsCallingMethod(cls, sig, lim, page, pageSize).getItems()).toString();
+                } else if (req.has("findBeansWithAnnotation")) {
+                    Object val = req.get("findBeansWithAnnotation");
+                    String ann;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        ann = o.getString("annotation");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        ann = val.toString();
+                    }
+                    response = new JSONArray(queryService.findBeansWithAnnotation(ann, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("searchByAnnotation")) {
+                    JSONObject o = req.getJSONObject("searchByAnnotation");
+                    String ann = o.getString("annotation");
+                    String target = o.optString("targetType", "class");
+                    Integer limit = o.has("limit") ? o.getInt("limit") : null;
+                    Integer page = o.has("page") ? o.getInt("page") : null;
+                    Integer pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    response = new JSONArray(queryService.searchByAnnotation(ann, target, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("findHttpEndpoints")) {
+                    JSONObject o = req.getJSONObject("findHttpEndpoints");
+                    String base = o.getString("basePath");
+                    String verb = o.getString("httpMethod");
+                    Integer limit = o.has("limit") ? o.getInt("limit") : null;
+                    Integer page = o.has("page") ? o.getInt("page") : null;
+                    Integer pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    response = new JSONArray(queryService.findHttpEndpoints(base, verb, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("findControllersUsingService")) {
+                    Object val = req.get("findControllersUsingService");
+                    String svc;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        svc = o.getString("serviceClassName");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        svc = val.toString();
+                    }
+                    response = new JSONArray(queryService.findControllersUsingService(svc, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("findEventListeners")) {
+                    Object val = req.get("findEventListeners");
+                    String ev;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        ev = o.getString("eventType");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        ev = val.toString();
+                    }
+                    response = new JSONArray(queryService.findEventListeners(ev, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("findScheduledTasks")) {
+                    JSONObject o = req.optJSONObject("findScheduledTasks");
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (o != null) {
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    }
+                    response = new JSONArray(queryService.findScheduledTasks(limit, page, pageSize).getItems()).toString();
+                } else if (req.has("findConfigPropertyUsage")) {
+                    Object val = req.get("findConfigPropertyUsage");
+                    String key;
+                    Integer limit = null;
+                    Integer page = null;
+                    Integer pageSize = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        key = o.getString("propertyKey");
+                        limit = o.has("limit") ? o.getInt("limit") : null;
+                        page = o.has("page") ? o.getInt("page") : null;
+                        pageSize = o.has("pageSize") ? o.getInt("pageSize") : null;
+                    } else {
+                        key = val.toString();
+                    }
+                    response = new JSONArray(queryService.findConfigPropertyUsage(key, limit, page, pageSize).getItems()).toString();
+                } else if (req.has("getPackageHierarchy")) {
+                    Object val = req.get("getPackageHierarchy");
+                    String pkg;
+                    Integer depth = null;
+                    if (val instanceof JSONObject) {
+                        JSONObject o = (JSONObject) val;
+                        pkg = o.getString("rootPackage");
+                        depth = o.has("depth") ? o.getInt("depth") : null;
+                    } else {
+                        pkg = val.toString();
+                    }
+                    response = queryService.getPackageHierarchy(pkg, depth);
+                } else if (req.has("getGraphStatistics")) {
+                    Integer top = req.optInt("getGraphStatistics", -1);
+                    response = queryService.getGraphStatistics(top == -1 ? null : top);
+                } else if (req.has("exportGraph")) {
+                    JSONObject o = req.getJSONObject("exportGraph");
+                    String format = o.getString("format");
+                    String path = o.getString("outputPath");
+                    queryService.exportGraph(format, path);
+                    response = "{}";
+                }
+            }
+
+            byte[] bytes = formatEvent(response);
+            exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        }
+    }
+}

--- a/cli/src/test/java/tech/softwareologists/cli/SseMcpServerTest.java
+++ b/cli/src/test/java/tech/softwareologists/cli/SseMcpServerTest.java
@@ -1,0 +1,106 @@
+package tech.softwareologists.cli;
+
+import org.junit.Test;
+import tech.softwareologists.core.ManifestGenerator;
+import tech.softwareologists.core.QueryService;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+public class SseMcpServerTest {
+    @Test
+    public void manifestAndQuery_returnEvent() throws Exception {
+        QueryService qs = new QueryService() {
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findCallers(String className, Integer limit, Integer page, Integer pageSize) {
+                return new tech.softwareologists.core.QueryResult<>(Collections.singletonList("Caller"),1,1,1);
+            }
+            @Override public tech.softwareologists.core.QueryResult<String> findImplementations(String interfaceName, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findSubclasses(String className, int depth, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findDependencies(String className, Integer depth, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findBeansWithAnnotation(String annotation, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> searchByAnnotation(String annotation, String targetType, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findHttpEndpoints(String basePath, String httpMethod, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findControllersUsingService(String serviceClassName, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findEventListeners(String eventType, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findScheduledTasks(Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findConfigPropertyUsage(String propertyKey, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public String getPackageHierarchy(String rootPackage, Integer depth){ return "{}"; }
+            @Override public String getGraphStatistics(Integer topN){ return "{}"; }
+            @Override public void exportGraph(String format, String outputPath) {}
+        };
+        SseMcpServer server = new SseMcpServer(0, qs);
+        server.start();
+        int port = server.getPort();
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest manifestReq = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:" + port + "/mcp/manifest"))
+                .GET()
+                .build();
+        HttpResponse<String> manifestResp = client.send(manifestReq, HttpResponse.BodyHandlers.ofString());
+        String expectedManifest = ManifestGenerator.generate();
+        String manifestBody = manifestResp.body().replace("\r", "").trim();
+        if (!manifestBody.startsWith("data: {")) {
+            throw new AssertionError("Manifest event mismatch: " + manifestResp.body());
+        }
+
+        HttpRequest queryReq = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:" + port + "/mcp/query"))
+                .POST(HttpRequest.BodyPublishers.ofString("{\"findCallers\":\"X\"}"))
+                .header("Content-Type", "application/json")
+                .build();
+        HttpResponse<String> queryResp = client.send(queryReq, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        String queryBody = queryResp.body().replace("\r", "").trim();
+        if (!queryBody.startsWith("data: ") || queryBody.indexOf("[\"Caller\"]") == -1) {
+            throw new AssertionError("Unexpected query event: " + queryResp.body());
+        }
+        server.stop();
+    }
+
+    @Test
+    public void findCallersRequest_pagingParametersPassed() throws Exception {
+        QueryService qs = new QueryService() {
+            @Override
+            public tech.softwareologists.core.QueryResult<String> findCallers(String className, Integer limit, Integer page, Integer pageSize) {
+                if (!"A".equals(className) || limit == null || limit != 10 || page == null || page != 2 || pageSize == null || pageSize != 5) {
+                    throw new AssertionError("Paging parameters not forwarded");
+                }
+                return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0);
+            }
+            @Override public tech.softwareologists.core.QueryResult<String> findImplementations(String interfaceName, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findSubclasses(String className, int depth, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findDependencies(String className, Integer depth, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findPathBetweenClasses(String fromClass, String toClass, Integer maxDepth){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findMethodsCallingMethod(String className, String methodSignature, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findBeansWithAnnotation(String annotation, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> searchByAnnotation(String annotation, String targetType, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findHttpEndpoints(String basePath, String httpMethod, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findControllersUsingService(String serviceClassName, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findEventListeners(String eventType, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findScheduledTasks(Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public tech.softwareologists.core.QueryResult<String> findConfigPropertyUsage(String propertyKey, Integer limit, Integer page, Integer pageSize){ return new tech.softwareologists.core.QueryResult<>(Collections.emptyList(),1,0,0); }
+            @Override public String getPackageHierarchy(String rootPackage, Integer depth){ return "{}"; }
+            @Override public String getGraphStatistics(Integer topN){ return "{}"; }
+            @Override public void exportGraph(String format, String outputPath) {}
+        };
+        SseMcpServer server = new SseMcpServer(0, qs);
+        server.start();
+        int port = server.getPort();
+        HttpClient client = HttpClient.newHttpClient();
+        String body = "{\"findCallers\":{\"className\":\"A\",\"limit\":10,\"page\":2,\"pageSize\":5}}";
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:" + port + "/mcp/query"))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .header("Content-Type", "application/json")
+                .build();
+        client.send(req, HttpResponse.BodyHandlers.ofString());
+        server.stop();
+    }
+}

--- a/examples/sample-sse.sh
+++ b/examples/sample-sse.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Builds the CLI fat-JAR and runs a sample query against example.jar using SSE
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Build CLI fat JAR
+cd "$ROOT_DIR"
+gradle -q :cli:shadowJar
+CLI_JAR="$ROOT_DIR/cli/build/libs/cli-all.jar"
+
+# Prepare watch directory with provided example JAR
+WATCH_DIR="$(mktemp -d)"
+EXAMPLE_JAR="$SCRIPT_DIR/example.jar"
+if [[ ! -f "$EXAMPLE_JAR" ]]; then
+  echo "Missing $EXAMPLE_JAR. Run build-example-jar.sh first." >&2
+  exit 1
+fi
+cp "$EXAMPLE_JAR" "$WATCH_DIR/"
+
+PORT=8080
+java -jar "$CLI_JAR" --watch-dir "$WATCH_DIR" --sse-port "$PORT" &
+PID=$!
+sleep 1
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"findCallers":"dep.A"}' \
+  http://localhost:$PORT/mcp/query
+kill $PID
+rm -rf "$WATCH_DIR"


### PR DESCRIPTION
## Summary
- implement `SseMcpServer` to serve MCP queries over HTTP SSE
- support `--sse-port` option in `CliMain`
- add unit tests for `SseMcpServer`
- document SSE usage and example script

## Testing
- `gradle :cli:test`
- `gradle build -x :intellij:instrumentCode -x :intellij:buildPlugin`


------
https://chatgpt.com/codex/tasks/task_b_68747d5014ec832aad7f1a6d2f51438b