### PR TITLE
FIX-INTELLIJ-PLUGIN: include plugin descriptor

### DIFF
--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,6 +17,12 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
+sourceSets {
+    main {
+        resources.srcDir("resources")
+    }
+}
+
 dependencies {
     implementation(project(":core"))
     implementation("org.json:json:20240303")

--- a/intellij/src/test/java/tech/softwareologists/ij/PluginDescriptorTest.java
+++ b/intellij/src/test/java/tech/softwareologists/ij/PluginDescriptorTest.java
@@ -1,0 +1,10 @@
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class PluginDescriptorTest {
+    @Test
+    public void pluginXml_present_inClassPath() {
+        assertNotNull(
+            PluginDescriptorTest.class.getClassLoader().getResource("META-INF/plugin.xml"));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure plugin.xml packaged in IntelliJ plugin
- add regression test verifying plugin descriptor is on the classpath

## Testing
- `gradle :intellij:test`
- `gradle :intellij:buildPlugin`


------
https://chatgpt.com/codex/tasks/task_b_68747ef3e5b8832a9d9410e67389f747