### PR TITLE
FIX-INTELLIJ-001: update plugin compatibility

### DIFF
--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -4,9 +4,12 @@ plugins {
 
 intellij {
     pluginName.set("CodeGraphMcp")
-    version.set("2021.3")
+    // Target IntelliJ IDEA 2024.1 to support recent IDE versions
+    version.set("2024.1")
     type.set("IC")
     plugins.set(listOf("java"))
+    // Keep manually specified since/until-build values from plugin.xml
+    updateSinceUntilBuild.set(false)
 }
 
 java {

--- a/intellij/resources/META-INF/plugin.xml
+++ b/intellij/resources/META-INF/plugin.xml
@@ -4,7 +4,8 @@
     <version>0.1.0</version>
     <vendor email="support@softwareologists.tech" url="https://softwareologists.tech">Softwareologists</vendor>
     <description>Integrates the CodeGraph MCP server with IntelliJ IDEA.</description>
-    <idea-version since-build="213"/>
+    <!-- Compatible with IDE builds up to 251.* -->
+    <idea-version since-build="213" until-build="251.*"/>
     <depends>com.intellij.modules.platform</depends>
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="tech.softwareologists.ij.StartupActivity"/>


### PR DESCRIPTION
## Summary
- expand CodeGraph MCP plugin compatibility to IDE build 251.*
- disable automatic since/until build patching
- target IntelliJ Platform 2024.1

## Testing
- `gradle :core:test`
- `gradle :cli:test`
- `gradle spotlessCheck`
- `gradle build -x :intellij:buildPlugin` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68756793fa64832aac3b64e9b5cd125b