### PR TITLE
FEAT-IJ-005: show server status in settings

### DIFF
--- a/intellij/src/main/java/tech/softwareologists/ij/McpServerStatus.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/McpServerStatus.java
@@ -1,0 +1,18 @@
+package tech.softwareologists.ij;
+
+/**
+ * Holds the runtime status of the embedded MCP server.
+ */
+public class McpServerStatus {
+    private static volatile String status = "Server not started";
+
+    /** Returns the current server status message. */
+    public static String getStatus() {
+        return status;
+    }
+
+    /** Sets the current server status message. */
+    public static void setStatus(String s) {
+        status = s == null ? "" : s;
+    }
+}

--- a/intellij/src/main/java/tech/softwareologists/ij/StartupActivity.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/StartupActivity.java
@@ -10,6 +10,7 @@ import tech.softwareologists.core.QueryService;
 import tech.softwareologists.core.QueryServiceImpl;
 import tech.softwareologists.ij.server.HttpMcpServer;
 import tech.softwareologists.ij.settings.McpSettings;
+import tech.softwareologists.ij.McpServerStatus;
 
 /**
  * Project-level startup activity that logs when a project is opened.
@@ -36,8 +37,10 @@ public class StartupActivity implements com.intellij.openapi.startup.StartupActi
             QueryService queryService = new QueryServiceImpl(db.getDriver());
             HttpMcpServer server = new HttpMcpServer(settings.getPort(), queryService);
             server.start();
+            McpServerStatus.setStatus("Running on port " + server.getPort());
             LOG.info("MCP HTTP server started on port " + server.getPort());
         } catch (Exception e) {
+            McpServerStatus.setStatus("Failed to start server: " + e.getMessage());
             LOG.warn("Failed to import project classes", e);
         }
     }

--- a/intellij/src/main/java/tech/softwareologists/ij/settings/McpSettingsConfigurable.java
+++ b/intellij/src/main/java/tech/softwareologists/ij/settings/McpSettingsConfigurable.java
@@ -7,12 +7,15 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.awt.*;
 
+import tech.softwareologists.ij.McpServerStatus;
+
 /**
  * Settings panel allowing configuration of the MCP HTTP port and package filters.
  */
 public class McpSettingsConfigurable implements Configurable {
     private JTextField portField;
     private JTextField filterField;
+    private JLabel statusLabel;
     private JPanel panel;
 
     @Override
@@ -39,6 +42,13 @@ public class McpSettingsConfigurable implements Configurable {
         gc.gridx = 1;
         filterField = new JTextField(McpSettings.getInstance().getPackageFilters(), 20);
         panel.add(filterField, gc);
+
+        gc.gridx = 0;
+        gc.gridy = 2;
+        panel.add(new JLabel("Server Status:"), gc);
+        gc.gridx = 1;
+        statusLabel = new JLabel(McpServerStatus.getStatus());
+        panel.add(statusLabel, gc);
         return panel;
     }
 
@@ -71,6 +81,9 @@ public class McpSettingsConfigurable implements Configurable {
         McpSettings settings = McpSettings.getInstance();
         portField.setText(String.valueOf(settings.getPort()));
         filterField.setText(settings.getPackageFilters());
+        if (statusLabel != null) {
+            statusLabel.setText(McpServerStatus.getStatus());
+        }
     }
 
     @Override
@@ -78,5 +91,6 @@ public class McpSettingsConfigurable implements Configurable {
         panel = null;
         portField = null;
         filterField = null;
+        statusLabel = null;
     }
 }


### PR DESCRIPTION
## Summary
- expose `McpServerStatus` class to track plugin HTTP server status
- update startup activity to record running/failed state
- display server status message in the settings panel

## Testing
- `gradle :intellij:buildPlugin`
- `gradle spotlessCheck`
- `gradle build` *(failed: Process 'Gradle Test Executor 5' finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_b_68758eb14554832a97bcadac2e7937dc