### PR TITLE
FEAT-BUILD-001: gradle 9 compatibility update

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -23,14 +23,16 @@ jobs:
               - 'cli/**'
             intellij:
               - 'intellij/**'
+      - name: Generate Gradle Wrapper
+        run: gradle wrapper --gradle-version 9.0-rc-2 --distribution-type all --console=plain
       - name: Spotless Check
-        run: gradle spotlessCheck
+        run: ./gradlew spotlessCheck
       - name: Core Tests
         if: steps.changes.outputs.core == 'true'
-        run: gradle :core:test
+        run: ./gradlew :core:test
       - name: CLI Tests
         if: steps.changes.outputs.cli == 'true'
-        run: gradle :cli:test
+        run: ./gradlew :cli:test
       - name: IntelliJ Plugin Build
         if: steps.changes.outputs.intellij == 'true'
-        run: gradle :intellij:buildPlugin
+        run: ./gradlew :intellij:buildPlugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Generate Gradle Wrapper
-        run: gradle wrapper --gradle-version 8.5 --distribution-type all --console=plain
+        run: gradle wrapper --gradle-version 9.0-rc-2 --distribution-type all --console=plain
       - name: Build Artifacts
         run: ./gradlew :cli:shadowJar :intellij:buildPlugin --no-daemon --console=plain
       - name: Detect Tag

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `java-library`
-    id("com.diffplug.spotless") version "6.25.0"
+    id("com.diffplug.spotless") version "7.1.0"
 }
 
 subprojects {

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.intellij") version "1.17.3"
+    id("org.jetbrains.intellij") version "1.17.4"
 }
 
 intellij {


### PR DESCRIPTION
## Summary
- upgrade spotless to 7.1.0
- upgrade IntelliJ plugin to 1.17.4
- update CI workflows to generate a Gradle 9 wrapper and use it

## Testing
- `./gradlew :core:test`
- `./gradlew :cli:test`
- `./gradlew :intellij:buildPlugin`


------
https://chatgpt.com/codex/tasks/task_b_68747d31c5e0832aa2d8669d1ff070f6