### PR TITLE
FEAT-IJ-006: add pipeline changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - name: Generate Gradle Wrapper
-        run: gradle wrapper --gradle-version 8.5 --distribution-type all --console=plain
-      - name: Build Artifacts
-        run: ./gradlew :cli:shadowJar :intellij:buildPlugin --no-daemon --console=plain
       - name: Detect Tag
         id: tag
         run: |
@@ -27,6 +19,16 @@ jobs:
           else
             echo "tag_name=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
           fi
+      - name: Generate Plugin Changelog
+        run: ./scripts/generate-intellij-changelog.sh "${{ steps.tag.outputs.tag_name }}"
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Generate Gradle Wrapper
+        run: gradle wrapper --gradle-version 8.5 --distribution-type all --console=plain
+      - name: Build Artifacts
+        run: ./gradlew :cli:shadowJar :intellij:buildPlugin --no-daemon --console=plain
       - name: Pre-release Check
         id: pre
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ gradle/wrapper/
 gradlew
 gradlew.bat
 examples/example.jar
+intellij/CHANGELOG.md

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -31,3 +31,12 @@ dependencies {
     implementation("org.json:json:20240303")
     testImplementation(project(":core"))
 }
+
+tasks {
+    patchPluginXml {
+        changeNotes.set(provider {
+            val f = file("CHANGELOG.md")
+            if (f.exists()) f.readText() else ""
+        })
+    }
+}

--- a/scripts/generate-intellij-changelog.sh
+++ b/scripts/generate-intellij-changelog.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Generates CHANGELOG.md for the IntelliJ plugin based on git tags
+set -euo pipefail
+
+TAG="${1:-}"
+if [[ -z "$TAG" ]]; then
+  TAG="$(git describe --tags --abbrev=0)"
+fi
+PREV_TAG=""
+if git rev-parse "$TAG^" >/dev/null 2>&1; then
+  PREV_TAG="$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)"
+fi
+
+CHANGELOG_FILE="intellij/CHANGELOG.md"
+{
+  echo "# IntelliJ Plugin Release Notes"
+  echo
+  echo "## $TAG"
+  if [[ -n "$PREV_TAG" ]]; then
+    git log "$PREV_TAG".."$TAG" --pretty=format:'- %s'
+  else
+    git log "$TAG" --pretty=format:'- %s'
+  fi
+} > "$CHANGELOG_FILE"
+
+printf "Generated %s for tag %s\n" "$CHANGELOG_FILE" "$TAG"


### PR DESCRIPTION
## Summary
- remove static changelog file from the plugin module
- add script to generate plugin changelog from git tags
- call the script in the release workflow before building
- load change notes only if the generated file exists

## Testing
- `gradle spotlessApply`
- `gradle :intellij:buildPlugin --no-daemon --stacktrace`
- `gradle build` *(incomplete: stopped due to network issues)*

------
https://chatgpt.com/codex/tasks/task_b_6875a4406d68832a95eee1ea16fbfc6d