### PR TITLE
Update release pipeline for version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,13 @@ jobs:
           fi
       - name: Generate Plugin Changelog
         run: ./scripts/generate-intellij-changelog.sh "${{ steps.tag.outputs.tag_name }}"
+      - name: Update Version Files
+        run: |
+          ./scripts/update-version.sh "${{ steps.tag.outputs.tag_name }}"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git commit -am "chore: bump version to ${{ steps.tag.outputs.tag_name }}"
+          git push
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+NEW_VERSION="$1"
+
+# Update ManifestGenerator.java
+sed -i "s/1\.0\.1/${NEW_VERSION}/" core/src/main/java/tech/softwareologists/core/ManifestGenerator.java
+
+# Update manifest.json.tpl
+sed -i -E "s/(\"version\": \")[0-9]+\.[0-9]+\.[0-9]+(\")/\1${NEW_VERSION}\2/" core/manifest.json.tpl
+
+# Update IntelliJ plugin.xml
+sed -i -E "s/(<version>)[0-9]+\.[0-9]+\.[0-9]+(<\/version>)/\1${NEW_VERSION}\2/" intellij/resources/META-INF/plugin.xml
+
+# Update distribution file reference in docs
+sed -i -E "s/(CodeGraphMcp-)[0-9]+\.[0-9]+\.[0-9]+(\.zip)/\1${NEW_VERSION}\2/" examples/idea-launch.md
+
+echo "Updated version to ${NEW_VERSION}"


### PR DESCRIPTION
## Summary
- add `scripts/update-version.sh` to modify version strings across the repo
- update release workflow to run version bumping and commit the changes

## Testing
- `gradle wrapper --gradle-version 8.5 --distribution-type all --console=plain`
- `./gradlew build --no-daemon --console=plain` *(truncated output)*
- `./gradlew :core:test --no-daemon --console=plain` *(truncated output)*
- `./gradlew spotlessApply`

------
https://chatgpt.com/codex/tasks/task_b_68769a876f48832a8a7342d0d406159a